### PR TITLE
fix: pie center text color

### DIFF
--- a/src/utils/chart-ui/pie-center-text.ts
+++ b/src/utils/chart-ui/pie-center-text.ts
@@ -5,12 +5,13 @@ import {getLabelsSize} from '../chart/text';
 
 const MAX_FONT_SIZE = 64;
 
-export function pieCenterText(text: string, options?: {padding?: number}) {
+export function pieCenterText(text: string, options?: {padding?: number; color?: string}) {
     if (!text) {
         return undefined;
     }
 
     const padding = get(options, 'padding', 12);
+    const color = get(options, 'color', 'currentColor');
 
     return function (args: {series: {innerRadius: number}}) {
         let fontSize = MAX_FONT_SIZE;
@@ -24,7 +25,8 @@ export function pieCenterText(text: string, options?: {padding?: number}) {
             .text(text)
             .attr('text-anchor', 'middle')
             .attr('alignment-baseline', 'middle')
-            .style('font-size', `${fontSize}px`);
+            .style('font-size', `${fontSize}px`)
+            .style('fill', color);
 
         return container.node();
     };


### PR DESCRIPTION
Now in dark theme pie center text color is broken: https://preview.gravity-ui.com/charts/?path=/story/pie--pie-donut-totals&globals=theme:dark

<img width="454" alt="image" src="https://github.com/user-attachments/assets/a3fbda29-553c-4fef-bbeb-a4e7c702b160" />

This pr fixes "dark on dark" color, using `currentColor` (`var(--g-color-text-primary)`) and adds ability to configure color.