### PR TITLE
fix: support null values for plot bands range

### DIFF
--- a/src/types/chart/axis.ts
+++ b/src/types/chart/axis.ts
@@ -228,18 +228,18 @@ export interface AxisPlotBand extends AxisPlot {
      * Can be a number, a string (e.g., a category), or a timestamp if representing a date.
      * When representing a date, the value **must be a timestamp** (number of milliseconds since Unix epoch).
      *
-     * If the value is `-Infinity`, it will be treated as the start of the axis.
+     * If the value is `-Infinity` or `null`, it will be treated as the start of the axis.
      */
-    from: number | string;
+    from: number | string | null;
     /**
      * The end position of the plot band in axis units.
      *
      * Can be a number, a string (e.g., a category), or a timestamp if representing a date.
      * When representing a date, the value **must be a timestamp** (number of milliseconds since Unix epoch).
      *
-     * If the value is `Infinity`, it will be treated as the end of the axis.
+     * If the value is `Infinity` or `null`, it will be treated as the end of the axis.
      */
-    to: number | string;
+    to: number | string | null;
 }
 
 export interface AxisCrosshair extends Omit<AxisPlotLine, 'value' | 'label'> {

--- a/src/utils/chart/axis/common.ts
+++ b/src/utils/chart/axis/common.ts
@@ -116,8 +116,9 @@ export const getAxisPlotsPosition = (axis: PreparedAxis, split: PreparedSplit, w
 export function getBandsPosition(args: GetBandsPositionArgs): {from: number; to: number} {
     const {band, axisScale} = args;
     const range = axisScale.range();
-    const scalePosFrom = band.from === -Infinity ? range[0] : axisScale(band.from);
-    const scalePosTo = band.to === Infinity ? range[1] : axisScale(band.to);
+    const scalePosFrom =
+        band.from === -Infinity || band.from === null ? range[0] : axisScale(band.from);
+    const scalePosTo = band.to === Infinity || band.to === null ? range[1] : axisScale(band.to);
     const isX = args.axis === 'x';
 
     if (scalePosTo !== undefined && scalePosFrom !== undefined) {


### PR DESCRIPTION
### Summary
This PR adds support for null values in the from and to properties of plotBands.

- from: null now acts as -Infinity (start of the axis).
- to: null now acts as Infinity (end of the axis).

### Motivation
When chart configurations containing Infinity or -Infinity are serialized to JSON (e.g., to be stored on a server or sent via API), they are automatically converted to null because JSON does not support infinite numbers.

Previously, this caused issues when reloading configurations from a backend. Supporting null natively ensures that serialized configurations remain functional and consistent without manual post-processing.