### PR TITLE
fix(line,area): hide points outside user-defined y-axis range

### DIFF
--- a/src/__tests__/area-series.visual.test.tsx
+++ b/src/__tests__/area-series.visual.test.tsx
@@ -20,6 +20,7 @@ import {
 import type {ChartData} from '../types';
 
 import {generateSeriesData} from './__data__/utils';
+import {getAttachedLocator, getLocator, getLocatorBoundingBox} from './utils';
 
 test.describe('Area series', () => {
     test('Basic', async ({mount}) => {
@@ -791,6 +792,167 @@ test.describe('Area series', () => {
             };
             const component = await mount(<ChartTestStory data={chartData} />);
             await expect(component.getByText('Annotated')).toHaveCount(1);
+        });
+    });
+
+    test.describe.only('Out-of-range points', () => {
+        test('empty line and region when axis.min is above all data', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: -3},
+                                {x: 2, y: -2},
+                                {x: 3, y: -4},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getAttachedLocator({
+                component,
+                selector: '.gcharts-area__line',
+            });
+            const regionPath = await getAttachedLocator({
+                component,
+                selector: '.gcharts-area__region',
+            });
+            const lineD = await linePath.getAttribute('d');
+            const regionD = await regionPath.getAttribute('d');
+            expect(lineD).toBeNull();
+            expect(regionD).toBeNull();
+        });
+
+        test('empty line and region when axis.max is below all data', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: 50},
+                                {x: 2, y: 60},
+                                {x: 3, y: 55},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{max: 0}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getAttachedLocator({
+                component,
+                selector: '.gcharts-area__line',
+            });
+            const regionPath = await getAttachedLocator({
+                component,
+                selector: '.gcharts-area__region',
+            });
+            const lineD = await linePath.getAttribute('d');
+            const regionD = await regionPath.getAttribute('d');
+            expect(lineD).toBeNull();
+            expect(regionD).toBeNull();
+        });
+
+        test('no hover marker when all points are out of range', async ({mount, page}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: -3},
+                                {x: 2, y: -2},
+                                {x: 3, y: -4},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const svg = await getLocator({component, selector: 'svg'});
+            const box = await getLocatorBoundingBox(svg);
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+            // Default area series has marker.normal disabled, so any
+            // .gcharts-marker__wrapper in the DOM would be a hover marker.
+            const hoverMarkers = component.locator('.gcharts-marker__wrapper');
+            await expect(hoverMarkers).toHaveCount(0);
+        });
+
+        test('anchor neighbors extend the visible cluster by one point on each side', async ({
+            mount,
+        }) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: -10},
+                                {x: 2, y: -5},
+                                {x: 3, y: 5},
+                                {x: 4, y: 8},
+                                {x: 5, y: 4},
+                                {x: 6, y: -5},
+                                {x: 7, y: -10},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0, max: 10}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getLocator({component, selector: '.gcharts-area__line'});
+            const d = (await linePath.getAttribute('d')) ?? '';
+            // 3 in-range + 2 anchor neighbors = 5 points = 1 M + 4 L commands.
+            // Without anchors we'd get only 3 points (1 M + 2 L), so this catches
+            // a regression where anchor logic stops preserving out-of-range
+            // neighbors of visible points.
+            const moveCount = (d.match(/M/g) ?? []).length;
+            const lineCount = (d.match(/L/g) ?? []).length;
+            expect(moveCount).toBe(1);
+            expect(lineCount).toBe(4);
+        });
+
+        test('out-of-range gap between visible clusters splits the path', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: 5},
+                                {x: 2, y: -10},
+                                {x: 3, y: -10},
+                                {x: 4, y: -10},
+                                {x: 5, y: 5},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0, max: 10}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getLocator({component, selector: '.gcharts-area__line'});
+            const d = (await linePath.getAttribute('d')) ?? '';
+            // Defined sequence [def, def, skip, def, def] → two separate subpaths.
+            const moveCount = (d.match(/M/g) ?? []).length;
+            expect(moveCount).toBe(2);
         });
     });
 });

--- a/src/__tests__/area-series.visual.test.tsx
+++ b/src/__tests__/area-series.visual.test.tsx
@@ -795,7 +795,7 @@ test.describe('Area series', () => {
         });
     });
 
-    test.describe.only('Out-of-range points', () => {
+    test.describe('Out-of-range points', () => {
         test('empty line and region when axis.min is above all data', async ({mount}) => {
             const chartData: ChartData = {
                 series: {

--- a/src/__tests__/line-series.visual.test.tsx
+++ b/src/__tests__/line-series.visual.test.tsx
@@ -14,7 +14,7 @@ import {
 import type {ChartData} from '../types';
 
 import {generateSeriesData} from './__data__/utils';
-import {getLocatorBoundingBox} from './utils';
+import {getAttachedLocator, getLocator, getLocatorBoundingBox} from './utils';
 
 test.describe('Line series', () => {
     test.beforeEach(async ({page}) => {
@@ -722,6 +722,157 @@ test.describe('Line series', () => {
             };
             const component = await mount(<ChartTestStory data={chartData} />);
             await expect(component.getByText('Annotated')).toHaveCount(1);
+        });
+    });
+
+    test.describe('Out-of-range points', () => {
+        test('empty path when axis.min is above all data', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'line',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: -3},
+                                {x: 2, y: -2},
+                                {x: 3, y: -4},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getAttachedLocator({
+                component,
+                selector: '.gcharts-line > path',
+            });
+            await expect(linePath).toHaveCount(1);
+            const d = await linePath.getAttribute('d');
+            expect(d).toBeNull();
+        });
+
+        test('empty path when axis.max is below all data', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'line',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: 50},
+                                {x: 2, y: 60},
+                                {x: 3, y: 55},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{max: 0}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getAttachedLocator({
+                component,
+                selector: '.gcharts-line > path',
+            });
+            const d = await linePath.getAttribute('d');
+            expect(d).toBeNull();
+        });
+
+        test('no hover marker when all points are out of range', async ({mount, page}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'line',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: -3},
+                                {x: 2, y: -2},
+                                {x: 3, y: -4},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const svg = await getLocator({component, selector: 'svg'});
+            const box = await getLocatorBoundingBox(svg);
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+            const hoverMarkers = component.locator('.gcharts-marker__wrapper');
+            await expect(hoverMarkers).toHaveCount(0);
+        });
+
+        test('anchor neighbors extend the visible cluster by one point on each side', async ({
+            mount,
+        }) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'line',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: -10},
+                                {x: 2, y: -5},
+                                {x: 3, y: 5},
+                                {x: 4, y: 8},
+                                {x: 5, y: 4},
+                                {x: 6, y: -5},
+                                {x: 7, y: -10},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0, max: 10}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getLocator({component, selector: '.gcharts-line > path'});
+            const d = (await linePath.getAttribute('d')) ?? '';
+            // 3 in-range + 2 anchor neighbors = 5 points = 1 M + 4 L commands.
+            // Without anchors we'd get only 3 points (1 M + 2 L), so this catches
+            // a regression where anchor logic stops preserving out-of-range
+            // neighbors of visible points.
+            const moveCount = (d.match(/M/g) ?? []).length;
+            const lineCount = (d.match(/L/g) ?? []).length;
+            expect(moveCount).toBe(1);
+            expect(lineCount).toBe(4);
+        });
+
+        test('out-of-range gap between visible clusters splits the path', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'line',
+                            name: 'Series',
+                            data: [
+                                {x: 1, y: 5},
+                                {x: 2, y: -10},
+                                {x: 3, y: -10},
+                                {x: 4, y: -10},
+                                {x: 5, y: 5},
+                            ],
+                        },
+                    ],
+                },
+                yAxis: [{min: 0, max: 10}],
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const linePath = await getLocator({component, selector: '.gcharts-line > path'});
+            const d = (await linePath.getAttribute('d')) ?? '';
+            // Two in-range points at the edges, a wide out-of-range valley between them.
+            // idx 0 is in-range, idx 1 is its anchor (kept). idx 2 has both neighbors
+            // out-of-range → hiddenInLine. idx 3 is anchor of idx 4, idx 4 is in-range.
+            // Defined sequence: [def, def, skip, def, def] → two separate subpaths.
+            const moveCount = (d.match(/M/g) ?? []).length;
+            expect(moveCount).toBe(2);
         });
     });
 });

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -5,10 +5,31 @@ import type {Locator, Page} from '@playwright/test';
 /** Same shape as Playwright `locator.boundingBox()` (not `DOMRect`: no top/left/right/bottom). */
 export type LocatorBoundingBox = {x: number; y: number; width: number; height: number};
 
+/**
+ * Waits for the element to be visible before returning the locator. Use this
+ * when the test needs to interact with a rendered element (read its bounding
+ * box, simulate mouse events on it, parse its attributes) and you want a clear
+ * failure if the chart hasn't painted it yet. For elements that can
+ * legitimately exist without a visible bounding box — an SVG `<path>` with an
+ * empty `d`, for example — use `getAttachedLocator` instead.
+ */
 export async function getLocator(args: {component: MountResult; selector: string}) {
     const {component, selector} = args;
     const locator = component.locator(selector);
     await expect(locator).toBeVisible();
+
+    return locator;
+}
+
+/**
+ * Waits for the element to be attached to the DOM without requiring visibility.
+ * Useful for SVG paths that can legitimately have a zero-size bounding box
+ * (e.g. empty `d` attribute), which Playwright's `toBeVisible()` rejects.
+ */
+export async function getAttachedLocator(args: {component: MountResult; selector: string}) {
+    const {component, selector} = args;
+    const locator = component.locator(selector);
+    await expect(locator).toBeAttached();
 
     return locator;
 }

--- a/src/core/scales/y-scale.ts
+++ b/src/core/scales/y-scale.ts
@@ -306,6 +306,21 @@ export function createYScale(args: {
                     yMax = hasSeriesWithVolumeOnYAxis ? Math.max(yMaxDomain, 0) : yMaxDomain;
                 }
 
+                // When the user pins min/max on the wrong side of all data, d3 produces
+                // either an inverted scale (yMax<yMin, silently flips the axis) or a
+                // degenerate one (yMax===yMin, maps everything to the range midpoint);
+                // both leave phantom hover targets inside an empty plot. Compare against
+                // the raw data extent — upstream coercions like volume-series
+                // `yMax = Math.max(yMaxDomain, 0)` can make the post-coerced yMin/yMax
+                // lie about where data actually sits. Logarithmic has its own guard.
+                if (axis.type === 'linear') {
+                    if (typeof yMinPropsOrState === 'number' && yMaxDomain < yMin) {
+                        yMax = yMin + Math.max(Math.abs(yMin), 1);
+                    } else if (typeof yMaxPropsOrState === 'number' && yMinDomain > yMax) {
+                        yMin = yMax - Math.max(Math.abs(yMax), 1);
+                    }
+                }
+
                 const scaleFn = axis.type === 'logarithmic' ? scaleLog : scaleLinear;
                 let scale = scaleFn().domain([yMin, yMax]).range(range);
 

--- a/src/core/scales/y-scale.ts
+++ b/src/core/scales/y-scale.ts
@@ -306,17 +306,23 @@ export function createYScale(args: {
                     yMax = hasSeriesWithVolumeOnYAxis ? Math.max(yMaxDomain, 0) : yMaxDomain;
                 }
 
-                // When the user pins min/max on the wrong side of all data, d3 produces
-                // either an inverted scale (yMax<yMin, silently flips the axis) or a
-                // degenerate one (yMax===yMin, maps everything to the range midpoint);
-                // both leave phantom hover targets inside an empty plot. Compare against
-                // the raw data extent — upstream coercions like volume-series
-                // `yMax = Math.max(yMaxDomain, 0)` can make the post-coerced yMin/yMax
-                // lie about where data actually sits. Logarithmic has its own guard.
+                // When the user pins only one of min/max on the wrong side of all data,
+                // d3 produces either an inverted scale (yMax<yMin, silently flips the
+                // axis) or a degenerate one (yMax===yMin, maps everything to the range
+                // midpoint); both leave phantom hover targets inside an empty plot.
+                // Expand the auto-computed side so the scale stays sane. Only applies
+                // when the opposite bound is auto-derived — if the user supplied both
+                // bounds, trust the explicit range and let point filtering hide the
+                // rest. Comparison uses the raw data extent because upstream coercions
+                // like volume-series `yMax = Math.max(yMaxDomain, 0)` can make the
+                // post-coerced yMin/yMax lie about where data actually sits.
+                // Logarithmic has its own guard.
                 if (axis.type === 'linear') {
-                    if (typeof yMinPropsOrState === 'number' && yMaxDomain < yMin) {
+                    const minIsUserSet = typeof yMinPropsOrState === 'number';
+                    const maxIsUserSet = typeof yMaxPropsOrState === 'number';
+                    if (minIsUserSet && !maxIsUserSet && yMaxDomain < yMin) {
                         yMax = yMin + Math.max(Math.abs(yMin), 1);
-                    } else if (typeof yMaxPropsOrState === 'number' && yMinDomain > yMax) {
+                    } else if (maxIsUserSet && !minIsUserSet && yMinDomain > yMax) {
                         yMin = yMax - Math.max(Math.abs(yMax), 1);
                     }
                 }

--- a/src/core/shapes/area/prepare-data.ts
+++ b/src/core/shapes/area/prepare-data.ts
@@ -9,7 +9,7 @@ import type {PreparedSplit} from '../../layout/split-types';
 import type {ChartScale} from '../../scales/types';
 import {prepareAnnotation} from '../../series/prepare-annotation';
 import type {AnnotationAnchor, PreparedAreaSeries, PreparedSeriesOptions} from '../../series/types';
-import {getXValue, getYValue} from '../../shapes/utils';
+import {getXValue, getYValue, markHiddenPointsOutOfYRange} from '../../shapes/utils';
 import {getDataCategoryValue, getLabelsSize, getTextSizeFn} from '../../utils';
 import {getFormattedValue} from '../../utils/format';
 
@@ -425,6 +425,12 @@ export const prepareAreaData = async (args: {
                     }
                     return result;
                 }, []);
+
+                markHiddenPointsOutOfYRange({
+                    points,
+                    yScale: seriesYScale,
+                    yAxisTop,
+                });
 
                 seriesStackData.push({
                     annotations,

--- a/src/core/shapes/area/renderer.ts
+++ b/src/core/shapes/area/renderer.ts
@@ -47,7 +47,7 @@ export function renderArea(
 
     const line = lineGenerator<PointData>()
         .x((d) => d.x)
-        .defined((d) => d.y !== null)
+        .defined((d) => d.y !== null && !d.hiddenInLine)
         .y((d) => d.y as number);
 
     plotSvgElement.selectAll('*').remove();
@@ -71,7 +71,7 @@ export function renderArea(
         .attr('stroke-linecap', 'round');
 
     const area = areaGenerator<PointData>()
-        .defined((d) => d.y !== null)
+        .defined((d) => d.y !== null && !d.hiddenInLine)
         .x((d) => d.x)
         .y0((d) => d.y0)
         .y1((d) => d.y as number);

--- a/src/core/shapes/area/types.ts
+++ b/src/core/shapes/area/types.ts
@@ -2,13 +2,14 @@ import type {AreaSeriesData, HtmlItem, LabelData} from '../../../types';
 import type {AnnotationAnchor, PreparedAnnotation, PreparedAreaSeries} from '../../series/types';
 
 export type PointData = {
-    y0: number;
-    x: number;
-    y: number | null;
-    data: AreaSeriesData;
-    series: PreparedAreaSeries;
     annotation?: PreparedAnnotation;
     color?: string;
+    data: AreaSeriesData;
+    hiddenInLine?: boolean;
+    series: PreparedAreaSeries;
+    x: number;
+    y: number | null;
+    y0: number;
 };
 
 export type MarkerPointData = PointData & {

--- a/src/core/shapes/line/prepare-data.ts
+++ b/src/core/shapes/line/prepare-data.ts
@@ -6,7 +6,7 @@ import {prepareAnnotation} from '../../series/prepare-annotation';
 import type {AnnotationAnchor, PreparedLineSeries, PreparedSeriesOptions} from '../../series/types';
 import {filterOverlappingLabels, getLabelsSize, getTextSizeFn} from '../../utils';
 import {getFormattedValue} from '../../utils/format';
-import {getXValue, getYValue} from '../utils';
+import {getXValue, getYValue, markHiddenPointsOutOfYRange} from '../utils';
 
 import type {MarkerData, MarkerPointData, PointData, PreparedLineData} from './types';
 
@@ -194,6 +194,15 @@ export const prepareLineData = async (args: {
             }
             return result;
         }, []);
+
+        markHiddenPointsOutOfYRange({
+            points,
+            yScale: seriesYScale,
+            yAxisTop,
+            axisMin: seriesYAxis.min,
+            axisMax: seriesYAxis.max,
+            getDataY: (p) => p.data.y,
+        });
 
         const result: PreparedLineData = {
             annotations,

--- a/src/core/shapes/line/renderer.ts
+++ b/src/core/shapes/line/renderer.ts
@@ -45,7 +45,7 @@ export function renderLine(
     const inactiveOptions = get(seriesOptions, 'line.states.inactive');
 
     const line = lineGenerator<PointData>()
-        .defined((d) => d.y !== null && d.x !== null)
+        .defined((d) => d.y !== null && d.x !== null && !d.hiddenInLine)
         .x((d) => d.x as number)
         .y((d) => d.y as number);
 

--- a/src/core/shapes/line/types.ts
+++ b/src/core/shapes/line/types.ts
@@ -3,12 +3,13 @@ import type {DashStyle, LineCap, LineJoin} from '../../constants';
 import type {AnnotationAnchor, PreparedAnnotation, PreparedLineSeries} from '../../series/types';
 
 export type PointData = {
-    x: number | null;
-    y: number | null;
-    data: LineSeriesData;
-    series: PreparedLineSeries;
     annotation?: PreparedAnnotation;
     color?: string;
+    data: LineSeriesData;
+    hiddenInLine?: boolean;
+    series: PreparedLineSeries;
+    x: number | null;
+    y: number | null;
 };
 export type MarkerPointData = PointData & {y: number; x: number};
 export type MarkerData = {

--- a/src/core/shapes/utils.ts
+++ b/src/core/shapes/utils.ts
@@ -89,6 +89,74 @@ export function getYValue(args: {
     return point.y === null ? null : yLinearScale(point.y as number);
 }
 
+// Slack for d3 scale rounding (a `500` edge can come back as `499.9999`).
+// Half a pixel matches the ±0.5 of a 1px centered stroke and far exceeds any
+// plausible float error.
+const Y_RANGE_PIXEL_TOLERANCE = 0.5;
+
+/**
+ * Hides out-of-range points from line/area path generators via `hiddenInLine`.
+ * Neighbors of in-range points are kept as anchors so the path retains its
+ * slope at the plot edges instead of stopping abruptly at the visible point.
+ *
+ * Pixel check alone is not enough: a degenerate/clamped scale domain (see the
+ * y-scale.ts guard) can map out-of-range data into the plot rectangle, leaving
+ * phantom hover targets. Pass `axisMin`/`axisMax` + `getDataY` to also reject
+ * points whose raw value is outside the user's intended range.
+ *
+ * Stacked shapes must NOT pass the data check — `point.data.y` is the unstacked
+ * value and doesn't reflect where the point actually lands on the plot.
+ */
+export function markHiddenPointsOutOfYRange<
+    P extends {y: number | null; hiddenInLine?: boolean},
+>(args: {
+    points: P[];
+    yScale: ChartScale;
+    yAxisTop: number;
+    axisMin?: number;
+    axisMax?: number;
+    getDataY?: (point: P) => unknown;
+}): void {
+    const {points, yScale, yAxisTop, axisMin, axisMax, getDataY} = args;
+    const [yRangeA, yRangeB] = yScale.range() as [number, number];
+    const yMinPx = yAxisTop + Math.min(yRangeA, yRangeB);
+    const yMaxPx = yAxisTop + Math.max(yRangeA, yRangeB);
+    const hasDataBoundsCheck =
+        Boolean(getDataY) && (typeof axisMin === 'number' || typeof axisMax === 'number');
+
+    const isInRange = (point: P): boolean => {
+        if (point.y === null) {
+            return false;
+        }
+
+        if (hasDataBoundsCheck) {
+            const dataY = getDataY?.(point);
+
+            if (typeof dataY === 'number') {
+                if (typeof axisMin === 'number' && dataY < axisMin) {
+                    return false;
+                }
+
+                if (typeof axisMax === 'number' && dataY > axisMax) {
+                    return false;
+                }
+            }
+        }
+
+        return (
+            point.y >= yMinPx - Y_RANGE_PIXEL_TOLERANCE &&
+            point.y <= yMaxPx + Y_RANGE_PIXEL_TOLERANCE
+        );
+    };
+
+    const inRange = points.map(isInRange);
+    for (let idx = 0; idx < points.length; idx++) {
+        if (!inRange[idx] && !inRange[idx - 1] && !inRange[idx + 1]) {
+            points[idx].hiddenInLine = true;
+        }
+    }
+}
+
 export function shapeKey(d: unknown) {
     return (d as {id?: string | number}).id || -1;
 }

--- a/src/core/utils/get-closest-data.ts
+++ b/src/core/utils/get-closest-data.ts
@@ -147,7 +147,7 @@ export function getClosestPoints(args: GetClosestPointsArgs): TooltipDataChunk[]
                 const linePoints = (list as PreparedLineData[]).reduce<ShapePoint[]>((acc, d) => {
                     acc.push(
                         ...d.points.reduce<ShapePoint[]>((accPoints, p) => {
-                            if (p.y !== null && p.x !== null) {
+                            if (p.y !== null && p.x !== null && !p.hiddenInLine) {
                                 accPoints.push({
                                     data: p.data,
                                     series: p.series as LineSeries,
@@ -166,16 +166,18 @@ export function getClosestPoints(args: GetClosestPointsArgs): TooltipDataChunk[]
             }
             case 'area': {
                 const areaPoints = (list as PreparedAreaData[]).reduce<ShapePoint[]>((acc, d) => {
-                    Array.prototype.push.apply(
-                        acc,
-                        d.points.map((p) => ({
+                    for (const p of d.points) {
+                        if (p.y === null || p.hiddenInLine) {
+                            continue;
+                        }
+                        acc.push({
                             data: p.data,
                             series: p.series as AreaSeries,
                             x: p.x,
                             y0: p.y0,
                             y1: p.y,
-                        })),
-                    );
+                        });
+                    }
                     return acc;
                 }, []);
                 closestPointsByXValue.push(...areaPoints);


### PR DESCRIPTION
## Summary

Fixes broken rendering and phantom hover markers on line/area charts when `axis.min`/`axis.max` sits on the wrong side of all data values (e.g. `min: 0` with all-negative data).

## Problem

d3 produced a broken y-scale in two flavors:

- **Inverted domain** (`yMax < yMin`) for line — axis silently flipped, out-of-range points landed inside the plot rectangle, hover surfaced phantom tooltips.
- **Degenerate domain** (`yMax === yMin`) for area, because volume-series coercion clamped `yMax` to `yMin`. d3 mapped every value to the range midpoint, so a single `0` tick appeared in the middle of an otherwise empty plot with hover still active.

## Fix

- **`createYScale` guard**: expand an inverted/degenerate domain by a small delta when the raw data extent falls on the wrong side of the user bound. Compares against the raw extent so it survives upstream coercions like `yMax = Math.max(yMaxDomain, 0)`. Scoped to `linear`.
- **`markHiddenPointsOutOfYRange` helper** in `shapes/utils`: sets `hiddenInLine` on out-of-range points, preserving in-range neighbors as anchors so the path keeps its slope at the plot edges. Line passes `getDataY` for a raw-value check; stacked area does not (data.y isn't the stacked pixel position).
- **Path generators and tooltip** honor the flag: line/area `defined()` predicates (both line and area generators in area renderer), plus `get-closest-data.ts` filtering for hover. Area tooltip branch also got a small type-safety cleanup.