### PR TITLE
feat(tooltip): support custom formatter function in valueFormat

### DIFF
--- a/docs/diplodoc/pages/guides/tooltip.md
+++ b/docs/diplodoc/pages/guides/tooltip.md
@@ -106,3 +106,75 @@ tooltip: {
   },
 }
 ```
+
+### Custom formatter
+
+When the built-in `number` and `date` formatters aren't enough, use `{ type: 'custom' }`
+to provide your own formatter function. This is useful for things like byte sizes,
+currency with locale-aware rules, compound units, or any domain-specific formatting.
+
+The `formatter` receives `{value}` and must return a string. The same `ValueFormat`
+shape is accepted in `tooltip.valueFormat`, `tooltip.headerFormat`, and `dataLabels.format`.
+
+**Example:** Display raw bytes as a human-readable size (KB, MB, GB, ...).
+
+```javascript
+const formatBytes = ({value}) => {
+  const bytes = Number(value);
+  if (!Number.isFinite(bytes)) return String(value);
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(Math.abs(bytes) || 1) / Math.log(1024)),
+  );
+  return `${(bytes / 1024 ** i).toFixed(1)} ${units[i]}`;
+};
+
+{
+  series: {
+    data: [
+      {
+        type: 'line',
+        name: 'Downloaded',
+        data: [/* y in bytes */],
+      },
+    ],
+  },
+  tooltip: {
+    valueFormat: {type: 'custom', formatter: formatBytes},
+  },
+}
+```
+
+### Per-series override
+
+The value format set on `tooltip.valueFormat` applies to every series in the chart.
+If a specific series needs a different format — for example, when the chart mixes
+bytes, durations, and counts — override it via `series.tooltip.valueFormat`. The
+series-level setting takes precedence over the chart-level one for that series only.
+
+```javascript
+{
+  series: {
+    data: [
+      {
+        type: 'line',
+        name: 'Bandwidth',
+        data: [/* ... */],
+        tooltip: {
+          valueFormat: {type: 'custom', formatter: formatBytes},
+        },
+      },
+      {
+        type: 'line',
+        name: 'Requests',
+        data: [/* ... */],
+        // falls back to tooltip.valueFormat below
+      },
+    ],
+  },
+  tooltip: {
+    valueFormat: {type: 'number', precision: 0},
+  },
+}
+```

--- a/src/__stories__/Other/Tooltip/Tooltip.stories.tsx
+++ b/src/__stories__/Other/Tooltip/Tooltip.stories.tsx
@@ -10,6 +10,7 @@ import {
     tooltipOverflowedRowsHtmlData,
     tooltipRowRendererHtmlData,
     tooltipTotalsSumData,
+    tooltipWithCustomFormatter,
     tooltipWithDateFormat,
     tooltipWithNumberFormat,
 } from '../../__data__';
@@ -40,6 +41,11 @@ const TooltipFormattedValues = () => {
                 </Col>
                 <Col s={6}>
                     <ChartStory data={tooltipWithDateFormat} />
+                </Col>
+            </Row>
+            <Row space={2}>
+                <Col s={12}>
+                    <ChartStory data={tooltipWithCustomFormatter} />
                 </Col>
             </Row>
         </Container>

--- a/src/__stories__/__data__/other/tooltip/formats.ts
+++ b/src/__stories__/__data__/other/tooltip/formats.ts
@@ -50,6 +50,53 @@ export const tooltipWithNumberFormat: ChartData = {
     },
 };
 
+const formatBytes = ({value}: {value: unknown}) => {
+    const bytes = Number(value);
+    if (!Number.isFinite(bytes)) {
+        return String(value);
+    }
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(
+        units.length - 1,
+        Math.floor(Math.log(Math.abs(bytes) || 1) / Math.log(1024)),
+    );
+    return `${(bytes / 1024 ** i).toFixed(1)} ${units[i]}`;
+};
+
+export const tooltipWithCustomFormatter: ChartData = {
+    series: {
+        data: [
+            {
+                name: 'Downloaded',
+                type: 'line',
+                data: [
+                    {x: 1, y: 512},
+                    {x: 2, y: 2 * 1024},
+                    {x: 3, y: 512 * 1024},
+                    {x: 4, y: 5 * 1024 * 1024},
+                    {x: 5, y: 120 * 1024 * 1024},
+                    {x: 6, y: 1.2 * 1024 * 1024 * 1024},
+                ],
+                dataLabels: {
+                    enabled: true,
+                    format: {type: 'custom', formatter: formatBytes},
+                },
+            },
+        ],
+    },
+    tooltip: {
+        valueFormat: {type: 'custom', formatter: formatBytes},
+    },
+    yAxis: [
+        {
+            type: 'logarithmic',
+        },
+    ],
+    title: {
+        text: 'Bytes (custom formatter)',
+    },
+};
+
 export const tooltipWithDateFormat: ChartData = (() => {
     const date = new Date('2025-10-17T13:51:01').getTime();
 

--- a/src/components/Tooltip/DefaultTooltipContent/__tests__/DefaultTooltipContent.test.tsx
+++ b/src/components/Tooltip/DefaultTooltipContent/__tests__/DefaultTooltipContent.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+
+import {ThemeProvider} from '@gravity-ui/uikit';
+import {render} from '@testing-library/react';
+
+import type {TooltipDataChunk} from '../../../../types';
+import {DefaultTooltipContent} from '../index';
+
+function makeLineChunk(
+    name: string,
+    y: number,
+    tooltip?: {valueFormat?: {type: 'custom'; formatter: (args: {value: unknown}) => string}},
+): TooltipDataChunk {
+    // `tooltip` is not declared on TooltipDataChunkLine.series, but at runtime
+    // the hovered chunk carries a prepared series which includes it — mimic that.
+    return {
+        data: {x: 1, y},
+        series: {type: 'line', id: name, name, ...(tooltip ? {tooltip} : {})} as never,
+    };
+}
+
+function renderTooltip(ui: React.ReactElement) {
+    return render(<ThemeProvider theme="light">{ui}</ThemeProvider>);
+}
+
+describe('DefaultTooltipContent — valueFormat precedence', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('series.tooltip.valueFormat takes precedence over chart tooltip.valueFormat', () => {
+        const chartFormatter = jest.fn(({value}) => `chart:${value}`);
+        const seriesFormatter = jest.fn(({value}) => `series:${value}`);
+
+        const hovered: TooltipDataChunk[] = [
+            makeLineChunk('Overridden', 10, {
+                valueFormat: {type: 'custom', formatter: seriesFormatter},
+            }),
+            makeLineChunk('Inherited', 20),
+        ];
+
+        const {container} = renderTooltip(
+            <DefaultTooltipContent
+                hovered={hovered}
+                valueFormat={{type: 'custom', formatter: chartFormatter}}
+                yAxis={{type: 'linear'}}
+            />,
+        );
+
+        const text = container.textContent ?? '';
+
+        expect(text).toContain('series:10');
+        expect(text).toContain('chart:20');
+        expect(text).not.toContain('chart:10');
+        expect(text).not.toContain('series:20');
+
+        expect(seriesFormatter).toHaveBeenCalledWith({value: 10});
+        expect(chartFormatter).toHaveBeenCalledWith({value: 20});
+    });
+});

--- a/src/core/types/chart/base.ts
+++ b/src/core/types/chart/base.ts
@@ -14,7 +14,7 @@ type DateFormat = {
 
 export type CustomFormat = {
     type: 'custom';
-    formatter: (args: {value: unknown; formattedValue?: string}) => string;
+    formatter: (args: {value: unknown}) => string;
 };
 
 /**
@@ -22,7 +22,10 @@ export type CustomFormat = {
  *
  * - `{ type: 'number' }` — numeric formatting with optional precision, units, percent display, etc.
  * See [FormatNumberOptions](https://gravity-ui.github.io/charts/pages/api/Utilities/interfaces/FormatNumberOptions.html) for all available options.
- * - `{ type: 'date' }` — date/time formatting
+ * - `{ type: 'date' }` — date/time formatting.
+ * - `{ type: 'custom' }` — user-defined formatter function. Receives the raw `value`
+ *   and returns the display string. Use it when the built-in number/date formatters
+ *   are not enough (e.g. bytes → KB/MB/GB, currency with locale, etc.).
  * @example
  * // Two decimal places, shown as percent
  * { type: 'number', precision: 2, format: 'percent' }
@@ -32,8 +35,20 @@ export type CustomFormat = {
  * @example
  * // Date value (Unix ms) formatted as "17 October 2025"
  * { type: 'date', format: 'DD MMMM YYYY' }
+ * @example
+ * // Bytes → human-readable size
+ * {
+ *   type: 'custom',
+ *   formatter: ({value}) => {
+ *     const bytes = Number(value);
+ *     if (!Number.isFinite(bytes)) return String(value);
+ *     const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+ *     const i = Math.min(units.length - 1, Math.floor(Math.log(Math.abs(bytes) || 1) / Math.log(1024)));
+ *     return `${(bytes / 1024 ** i).toFixed(1)} ${units[i]}`;
+ *   },
+ * }
  */
-export type ValueFormat = NumberFormat | DateFormat;
+export type ValueFormat = NumberFormat | DateFormat | CustomFormat;
 
 export interface BaseDataLabels {
     /**

--- a/src/core/types/chart/tooltip.ts
+++ b/src/core/types/chart/tooltip.ts
@@ -6,7 +6,7 @@ import type {AreaSeries, AreaSeriesData} from './area';
 import type {AxisPlotBand, AxisPlotLine, AxisPlotShape, ChartXAxis, ChartYAxis} from './axis';
 import type {BarXSeries, BarXSeriesData} from './bar-x';
 import type {BarYSeries, BarYSeriesData} from './bar-y';
-import type {CustomFormat, ValueFormat} from './base';
+import type {ValueFormat} from './base';
 import type {FunnelSeries, FunnelSeriesData} from './funnel';
 import type {HeatmapSeries, HeatmapSeriesData} from './heatmap';
 import type {LineSeries, LineSeriesData} from './line';
@@ -135,7 +135,7 @@ export interface ChartTooltipRendererArgs<T = MeaningfulAny> {
     xAxis?: ChartXAxis | null;
     yAxis?: ChartYAxis;
     /** Formatting settings for tooltip header row (includes computed default). */
-    headerFormat?: ValueFormat | CustomFormat;
+    headerFormat?: ValueFormat;
 }
 
 export interface ChartTooltipTotalsAggregationArgs<
@@ -206,7 +206,7 @@ export interface ChartTooltip<T = MeaningfulAny> {
     /** Formatting settings for tooltip value. */
     valueFormat?: ValueFormat;
     /** Formatting settings for tooltip header row. */
-    headerFormat?: ValueFormat | CustomFormat;
+    headerFormat?: ValueFormat;
     /** Settings for totals block in tooltip */
     totals?: {
         /**

--- a/src/core/utils/__tests__/format.test.ts
+++ b/src/core/utils/__tests__/format.test.ts
@@ -1,0 +1,113 @@
+import {getFormattedValue} from '../format';
+
+describe('getFormattedValue', () => {
+    describe('without format', () => {
+        test('returns String(value) for number', () => {
+            expect(getFormattedValue({value: 42})).toBe('42');
+        });
+
+        test('returns String(value) for string', () => {
+            expect(getFormattedValue({value: 'hello'})).toBe('hello');
+        });
+
+        test('returns "null" for null', () => {
+            expect(getFormattedValue({value: null})).toBe('null');
+        });
+
+        test('returns "undefined" for undefined', () => {
+            expect(getFormattedValue({value: undefined})).toBe('undefined');
+        });
+    });
+
+    describe('type: "number"', () => {
+        test('formats number with precision', () => {
+            // Locale-agnostic: decimal separator may be "." or ",".
+            expect(
+                getFormattedValue({value: 1.2345, format: {type: 'number', precision: 2}}),
+            ).toMatch(/^1[.,]23$/);
+        });
+
+        test('formats as percent', () => {
+            expect(
+                getFormattedValue({
+                    value: 0.156,
+                    format: {type: 'number', format: 'percent', precision: 1},
+                }),
+            ).toMatch(/^15[.,]6%$/);
+        });
+
+        test('falls back to String(value) when value is not a number', () => {
+            expect(getFormattedValue({value: 'abc', format: {type: 'number', precision: 2}})).toBe(
+                'abc',
+            );
+        });
+    });
+
+    describe('type: "date"', () => {
+        // 2024-01-15 00:00:00 UTC
+        const MIDNIGHT_JAN15 = 1705276800000;
+
+        test('formats timestamp with provided format', () => {
+            expect(
+                getFormattedValue({
+                    value: MIDNIGHT_JAN15,
+                    format: {type: 'date', format: 'YYYY-MM-DD'},
+                }),
+            ).toBe('2024-01-15');
+        });
+
+        test('falls back to String(value) for invalid date', () => {
+            expect(getFormattedValue({value: 'not-a-date', format: {type: 'date'}})).toBe(
+                'not-a-date',
+            );
+        });
+    });
+
+    describe('type: "custom"', () => {
+        test('invokes formatter with raw value and returns its result', () => {
+            const formatter = jest.fn(({value}) => `v:${value}`);
+
+            expect(getFormattedValue({value: 42, format: {type: 'custom', formatter}})).toBe(
+                'v:42',
+            );
+            expect(formatter).toHaveBeenCalledTimes(1);
+            expect(formatter).toHaveBeenCalledWith({value: 42});
+        });
+
+        test('works for string values', () => {
+            expect(
+                getFormattedValue({
+                    value: 'apple',
+                    format: {
+                        type: 'custom',
+                        formatter: ({value}) => String(value).toUpperCase(),
+                    },
+                }),
+            ).toBe('APPLE');
+        });
+
+        test('works for null values', () => {
+            expect(
+                getFormattedValue({
+                    value: null,
+                    format: {
+                        type: 'custom',
+                        formatter: ({value}) => (value === null ? '—' : String(value)),
+                    },
+                }),
+            ).toBe('—');
+        });
+
+        test('works for undefined values', () => {
+            expect(
+                getFormattedValue({
+                    value: undefined,
+                    format: {
+                        type: 'custom',
+                        formatter: ({value}) => (value === undefined ? 'n/a' : String(value)),
+                    },
+                }),
+            ).toBe('n/a');
+        });
+    });
+});

--- a/src/core/utils/format.ts
+++ b/src/core/utils/format.ts
@@ -5,7 +5,7 @@ import capitalize from 'lodash/capitalize';
 
 import {formatNumber, getDefaultUnit} from '../../libs';
 import type {FormatOptions} from '../../libs/format-number/types';
-import type {CustomFormat, ValueFormat} from '../../types';
+import type {ValueFormat} from '../../types';
 import type {PreparedAxis} from '../axes/types';
 import {DEFAULT_DATE_FORMAT} from '../constants';
 
@@ -37,7 +37,7 @@ function getFormattedDate(args: {value: DateTimeInput; format?: string}) {
 
 export function getFormattedValue(args: {
     value: string | number | undefined | null;
-    format?: ValueFormat | CustomFormat;
+    format?: ValueFormat;
 }) {
     const {value, format} = args;
 


### PR DESCRIPTION
## Summary

Closes #544.

Extend `ValueFormat` with a new `{ type: 'custom', formatter }` variant so users can fully control how values are rendered in tooltips and data labels when the built-in `number` and `date` formatters aren't expressive enough — for example, bytes → `KB`/`MB`/`GB`, currency with locale-aware rules, durations, or any domain-specific formatting.

```ts
const formatBytes = ({value}) => {
  const bytes = Number(value);
  if (!Number.isFinite(bytes)) return String(value);
  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
  const i = Math.min(
    units.length - 1,
    Math.floor(Math.log(Math.abs(bytes) || 1) / Math.log(1024)),
  );
  return `${(bytes / 1024 ** i).toFixed(1)} ${units[i]}`;
};

{
  tooltip: {
    valueFormat: {type: 'custom', formatter: formatBytes},
  },
}
```

## What's changed

- **`ValueFormat` type** — now `NumberFormat | DateFormat | CustomFormat`. The new variant is accepted everywhere `ValueFormat` was already used: `tooltip.valueFormat`, `tooltip.headerFormat`, per-series `series.tooltip.valueFormat`, `tooltip.totals.valueFormat`, and `dataLabels.format`. No breaking changes — existing `number`/`date` configurations keep working unchanged.
- **`CustomFormat.formatter`** — simplified to `(args: {value: unknown}) => string`. The `formattedValue?: string` field was removed: it was declared on the type but never populated at any call site, so exposing it was misleading.
- **Type cleanup** — removed the now-redundant `ValueFormat | CustomFormat` unions on `tooltip.headerFormat` and in `getFormattedValue`'s signature, since `CustomFormat` is now part of `ValueFormat`.

## Per-series override

The existing precedence rule is unchanged: `series.tooltip.valueFormat` wins over chart-level `tooltip.valueFormat` for that series only. This lets you mix, for example, a bytes formatter on a bandwidth series with a plain numeric formatter on a request-count series in the same chart.

## Docs & stories

- [`docs/diplodoc/pages/guides/tooltip.md`](docs/diplodoc/pages/guides/tooltip.md) — new **"Custom formatter"** section with a bytes → human-readable example, plus a separate **"Per-series override"** section explaining how to mix different formatters across series.
- [`src/__stories__/__data__/other/tooltip/formats.ts`](src/__stories__/__data__/other/tooltip/formats.ts) — new `tooltipWithCustomFormatter` story (line chart with `y` in bytes, tooltip and data labels both formatted via a custom `formatBytes` function).

## Notes for reviewers

- `tooltip.totals.valueFormat` retains its existing behavior: when a custom aggregation returns a string, that string is shown as-is regardless of `valueFormat` — the totals row only routes numeric aggregation results through `getFormattedValue`. This is pre-existing behavior, identical across all three format variants (`number`/`date`/`custom`), and intentional — a custom aggregation returning a pre-formatted string is assumed to have done its own formatting. Can be revisited separately if needed.
- `CustomFormat.formatter` is typed as `(args: {value: unknown}) => string`. The `unknown` is deliberate: different call sites pass different value types (numbers from tooltip rows, timestamps from header, strings from category axes in the future), and forcing a narrower type would require casts on the user side.
