### PR TITLE
fix: fix uneven grid step across month boundary

### DIFF
--- a/src/core/utils/__tests__/datetime-ticks.test.ts
+++ b/src/core/utils/__tests__/datetime-ticks.test.ts
@@ -1,0 +1,32 @@
+import {DAY} from '../../constants';
+import {getDateTimeTicks} from '../ticks/datetime';
+
+describe('getDateTimeTicks', () => {
+    it('produces evenly-spaced ticks across a month boundary with 2-day step', () => {
+        // Jan 24 – Feb 10 2024: triggers 2-day auto step (≈ 17 days / ~8 ticks)
+        const start = new Date('2024-01-24T00:00:00.000Z');
+        const stop = new Date('2024-02-10T00:00:00.000Z');
+        const ticks = getDateTimeTicks(start, stop);
+
+        expect(ticks.length).toBeGreaterThan(1);
+
+        const gaps = ticks.slice(1).map((t, i) => t.getTime() - ticks[i].getTime());
+
+        const expectedGap = 2 * DAY;
+        gaps.forEach((gap) => {
+            expect(gap).toBe(expectedGap);
+        });
+    });
+
+    it('produces evenly-spaced ticks across Jan 31 → Feb 1 boundary specifically', () => {
+        // Narrow window that forces the tick sequence through the exact Jan 31 / Feb 1 boundary
+        const start = new Date('2024-01-27T00:00:00.000Z');
+        const stop = new Date('2024-02-06T00:00:00.000Z');
+        const ticks = getDateTimeTicks(start, stop, 5);
+
+        const gaps = ticks.slice(1).map((t, i) => t.getTime() - ticks[i].getTime());
+
+        const uniqueGaps = [...new Set(gaps)];
+        expect(uniqueGaps).toHaveLength(1);
+    });
+});

--- a/src/core/utils/ticks/datetime.ts
+++ b/src/core/utils/ticks/datetime.ts
@@ -34,6 +34,11 @@ const tickIntervals: [CountableTimeInterval, number, number][] = [
     [utcYear, 1, YEAR],
 ];
 
+// utcDay.every(2) resets its day counter at the start of each month (field = getUTCDate() - 1),
+// so in a 31-day month the last tick lands on day 31 and the next tick is day 1 of the following
+// month — only 1 day apart. Filtering by absolute Unix day number avoids the monthly reset.
+const utcEvery2Days = utcDay.filter((d) => Math.floor(d.getTime() / DAY) % 2 === 0);
+
 function getDateTimeTickInterval(start: number, stop: number, count: number) {
     const target = Math.abs(stop - start) / count;
     const i = bisector(([, , step]) => step).right(tickIntervals, target);
@@ -48,6 +53,11 @@ function getDateTimeTickInterval(start: number, stop: number, count: number) {
 
     const [t, step] =
         tickIntervals[target / tickIntervals[i - 1][2] < tickIntervals[i][2] / target ? i - 1 : i];
+
+    if (t === utcDay && step === 2) {
+        return utcEvery2Days;
+    }
+
     return t.every(step);
 }
 


### PR DESCRIPTION
When the datetime axis auto-selects a 2-day tick interval, the grid spacing becomes uneven at month boundaries because d3's utcDay.every(2) resets its counter on the 1st of each month. In a 31-day month this produces a 1-day gap between the last day of the month and the 1st of the next. 

Fix: use utcDay.filter() with an absolute Unix-day index so the 2-day cadence is preserved across month boundaries.