### PR TITLE
feat(zoom): add xy zoom support for bar-x series

### DIFF
--- a/src/components/ChartInner/utils/__tests__/zoom.test.ts
+++ b/src/components/ChartInner/utils/__tests__/zoom.test.ts
@@ -82,6 +82,7 @@ describe('zoom/getZoomType', () => {
     test.each([
         {seriesData: [AREA_SERIES], zoomType: ZOOM_TYPE.XY, expected: ZOOM_TYPE.XY},
         {seriesData: [LINE_SERIES], zoomType: ZOOM_TYPE.XY, expected: ZOOM_TYPE.XY},
+        {seriesData: [BAR_X_SERIES], zoomType: ZOOM_TYPE.XY, expected: ZOOM_TYPE.XY},
         {seriesData: [BAR_X_SERIES], zoomType: ZOOM_TYPE.Y, expected: ZOOM_TYPE.X},
         {seriesData: [BAR_Y_SERIES], zoomType: ZOOM_TYPE.X, expected: ZOOM_TYPE.Y},
         {seriesData: [PIE_SERIES], zoomType: ZOOM_TYPE.X, expected: undefined},
@@ -107,6 +108,7 @@ describe('zoom/getZoomType', () => {
 
     test.each([
         {seriesData: [AREA_SERIES, BAR_X_SERIES], zoomType: ZOOM_TYPE.X, expected: ZOOM_TYPE.X},
+        {seriesData: [AREA_SERIES, BAR_X_SERIES], zoomType: ZOOM_TYPE.XY, expected: ZOOM_TYPE.XY},
         {seriesData: [AREA_SERIES, BAR_X_SERIES], zoomType: ZOOM_TYPE.Y, expected: ZOOM_TYPE.X},
         {
             seriesData: [AREA_SERIES, BAR_Y_SERIES, SCATTER_SERIES],

--- a/src/components/ChartInner/utils/zoom.ts
+++ b/src/components/ChartInner/utils/zoom.ts
@@ -12,7 +12,9 @@ function mapSeriesTypeToZoomType(seriesType: ChartSeries['type']): ZoomType[] {
         case SERIES_TYPE.Area: {
             return [ZOOM_TYPE.X, ZOOM_TYPE.XY, ZOOM_TYPE.Y];
         }
-        case SERIES_TYPE.BarX:
+        case SERIES_TYPE.BarX: {
+            return [ZOOM_TYPE.X, ZOOM_TYPE.XY];
+        }
         case SERIES_TYPE.XRange: {
             return [ZOOM_TYPE.X];
         }

--- a/src/core/types/chart/zoom.ts
+++ b/src/core/types/chart/zoom.ts
@@ -20,7 +20,8 @@ export interface ChartZoom {
      *
      * Supported zoom types by series type:
      * - `Area`, `Line`, `Scatter`: `x`, `y`, `xy`
-     * - `BarX`, `XRange`: `x`
+     * - `BarX`: `x`, `xy`
+     * - `XRange`: `x`
      * - `BarY`: `y`
      *
      * Default zoom type by series type:


### PR DESCRIPTION
Allow `zoom.type = 'xy'` for `bar-x` series (previously only `x` was supported)  