### PR TITLE
ci(docs): deploy via GitHub Pages artifacts

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -39,8 +39,6 @@ jobs:
         run: npm run docs:build
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - name: Write CNAME
-        run: echo 'gravity-ui.com' > ./dist-docs/CNAME
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -5,9 +5,18 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Build and Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,16 +33,27 @@ jobs:
       - name: Install dependencies
         run: npm run docs:deps
         shell: bash
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Build
         run: npm run docs:build
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Write CNAME
+        run: echo 'gravity-ui.com' > ./dist-docs/CNAME
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist-docs
-          cname: gravity-ui.com
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          path: ./dist-docs
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Migrate the docs deployment from `peaceiris/actions-gh-pages` (which pushes a new commit to the `gh-pages` branch on every deploy) to the GitHub Pages v2 artifact-based flow (`configure-pages` + `upload-pages-artifact` + `deploy-pages`).

## Why

Every deploy pushes a new commit to `gh-pages`, and the bundled `_examples/chart-examples.js` (~5 MB) is fully rewritten each time. Over 800+ deploys this has accumulated ~190 MB of history that is served to everyone who runs `git clone <repo>` without flags. The history itself is useless — each commit is a full rebuild from the same `main` SHA — but it inflates clone time and repository size for all contributors.

Pages v2 doesn't use a branch at all: the built site is uploaded as an artifact and served from a separate Pages storage on GitHub's side. Nothing to clone, nothing to accumulate.

## Changes

- Replace `peaceiris/actions-gh-pages@v3` with the canonical Pages v2 pipeline (`actions/configure-pages@v5` → `actions/upload-pages-artifact@v3` → `actions/deploy-pages@v4`).
- Split into separate `build` and `deploy` jobs, as recommended by the Pages v2 docs. The `deploy` job gets its own `environment: github-pages` and minimal permissions.
- Add top-level `permissions` (`pages: write`, `id-token: write`) and `concurrency: pages` — both required for Pages v2.
- Remove the redundant `if: github.ref == 'refs/heads/main'` guard — the workflow already triggers only on `push` to `main`.

No `CNAME` file is written and no custom domain is set on this repository. The `gravity-ui.com` apex domain is claimed by the organization's root Pages site; GitHub automatically routes `https://gravity-ui.com/charts/` to this project's Pages deployment, so this repo does not need to claim the domain itself.

## Deployment plan

This change requires coordinated manual steps in the repository Settings. The new workflow will fail if it runs before `Settings → Pages → Source` is switched.

### Before merge

1. **Review the workflow diff** in this PR.
2. **Switch the Pages source** — `Settings → Pages → Source`: change from `Deploy from a branch` to `GitHub Actions`.
3. **Leave Custom domain blank.** Attempting to set `gravity-ui.com` here returns an error because the apex domain is already owned by the organization's root Pages site. Project pages are served under the same apex automatically at `https://gravity-ui.com/<repo-name>/` — no action required from this repository.
4. **(Optional) Lock the deployment branch** — `Settings → Environments → github-pages → Deployment branches`: restrict to `main` to prevent accidental deploys from feature branches.

### Merge

5. Merge this PR. The `Documentation Deploy` workflow will run automatically on push to `main`.
6. Watch `Actions → Documentation Deploy` for the first run. Both `Build` and `Deploy` jobs should succeed; the deploy step exposes the page URL as an output.

### After merge (verification)

7. Open https://gravity-ui.com/charts/ — the site should render identically to before.
8. Click through a couple of sub-pages and examples to confirm assets under `_assets/`, `_bundle/`, `_examples/` load correctly (common regression point during Pages migrations).
9. Confirm the custom domain is still served by GitHub:
   ```bash
   curl -sI https://gravity-ui.com/charts/ | grep -i server
   # expected: Server: GitHub.com
   ```

### Cleanup (only after verification succeeds)

10. Delete the now-unused `gh-pages` branch:
    ```bash
    git push origin --delete gh-pages
    ```
11. GitHub runs `gc` on its side within 24–48h. After that, the repository size drops by ~190 MB:
    ```bash
    gh api repos/<owner>/<repo> --jq '.size'   # size in KB
    ```
12. Contributors do not need to do anything. Existing local clones keep working; new clones will be ~5× smaller.

## Rollback

If the first post-merge deploy fails or the site is broken:

- `Settings → Pages → Source` → switch back to `Deploy from a branch` → `gh-pages`. The old site is served again within a minute — nothing has been deleted yet.
- Investigate the failure, fix forward, re-switch to `GitHub Actions` when ready.

**Do not delete `gh-pages` until the Pages v2 deploy is confirmed working.** It is the rollback target.

## Out of scope

- CI job cloning behavior is unchanged — `actions/checkout@v4` already fetches only the triggering ref, so no CI job was ever pulling `gh-pages` blobs.
- PR preview workflows (`pr-docs-preview`, `pr-preview-*`, `main-preview`) are not affected; they deploy to Yandex S3, not GitHub Pages.
- PNG visual-test snapshots stay in regular git (no LFS). The history growth from snapshots (~3 MB/month) is not worth the LFS bandwidth cost.
