### PR TITLE
fix(zoom): correct stacked bar-x/bar-y/area rendering under xy zoom

### DIFF
--- a/src/__stories__/Other/Zoom/Zoom.stories.tsx
+++ b/src/__stories__/Other/Zoom/Zoom.stories.tsx
@@ -1,8 +1,17 @@
+import React from 'react';
+
 import type {Meta, StoryObj} from '@storybook/react';
+import cloneDeep from 'lodash/cloneDeep';
+import merge from 'lodash/merge';
 
 import {Chart} from '../../../components';
 import {ChartStory} from '../../ChartStory';
-import {barYStakingNormalData, lineTwoYAxisData, scatterBasicData} from '../../__data__';
+import {
+    barXStakingNormalData,
+    barYStakingNormalData,
+    lineTwoYAxisData,
+    scatterBasicData,
+} from '../../__data__';
 
 const meta: Meta<typeof ChartStory> = {
     title: 'Other/Zoom',
@@ -42,17 +51,32 @@ export const ZoomY = {
     },
 } satisfies Story;
 
+const scatterXY = merge(cloneDeep(scatterBasicData), {
+    chart: {zoom: {enabled: true, type: 'xy'}},
+    title: {text: 'Scatter'},
+});
+const barXStackedXY = merge(cloneDeep(barXStakingNormalData), {
+    chart: {zoom: {enabled: true, type: 'xy'}},
+    title: {text: 'Bar-x stacked'},
+});
+const barYStackedXY = merge(cloneDeep(barYStakingNormalData), {
+    chart: {zoom: {enabled: true, type: 'xy'}},
+    title: {text: 'Bar-y stacked'},
+});
+
 export const ZoomXY = {
     name: 'Type XY',
-    args: {
-        data: {
-            ...scatterBasicData,
-            chart: {
-                zoom: {
-                    enabled: true,
-                    type: 'xy',
-                },
-            },
-        },
-    },
+    render: () => (
+        <div style={{display: 'flex', flexDirection: 'column', gap: '20px'}}>
+            <div style={{height: 300}}>
+                <Chart data={scatterXY} />
+            </div>
+            <div style={{height: 300}}>
+                <Chart data={barXStackedXY} />
+            </div>
+            <div style={{height: 300}}>
+                <Chart data={barYStackedXY} />
+            </div>
+        </div>
+    ),
 } satisfies Story;

--- a/src/components/ChartInner/utils/__tests__/zoom.test.ts
+++ b/src/components/ChartInner/utils/__tests__/zoom.test.ts
@@ -85,6 +85,7 @@ describe('zoom/getZoomType', () => {
         {seriesData: [BAR_X_SERIES], zoomType: ZOOM_TYPE.XY, expected: ZOOM_TYPE.XY},
         {seriesData: [BAR_X_SERIES], zoomType: ZOOM_TYPE.Y, expected: ZOOM_TYPE.X},
         {seriesData: [BAR_Y_SERIES], zoomType: ZOOM_TYPE.X, expected: ZOOM_TYPE.Y},
+        {seriesData: [BAR_Y_SERIES], zoomType: ZOOM_TYPE.XY, expected: ZOOM_TYPE.XY},
         {seriesData: [PIE_SERIES], zoomType: ZOOM_TYPE.X, expected: undefined},
         {seriesData: [RADAR_SERIES], zoomType: ZOOM_TYPE.X, expected: undefined},
         {seriesData: [SANKEY_SERIES], zoomType: ZOOM_TYPE.X, expected: undefined},

--- a/src/components/ChartInner/utils/zoom.ts
+++ b/src/components/ChartInner/utils/zoom.ts
@@ -19,7 +19,7 @@ function mapSeriesTypeToZoomType(seriesType: ChartSeries['type']): ZoomType[] {
             return [ZOOM_TYPE.X];
         }
         case SERIES_TYPE.BarY: {
-            return [ZOOM_TYPE.Y];
+            return [ZOOM_TYPE.Y, ZOOM_TYPE.XY];
         }
         case SERIES_TYPE.Line: {
             return [ZOOM_TYPE.X, ZOOM_TYPE.XY, ZOOM_TYPE.Y];

--- a/src/core/series/prepare-area.ts
+++ b/src/core/series/prepare-area.ts
@@ -93,6 +93,7 @@ export function prepareArea(args: PrepareAreaSeriesArgs) {
             data: prepareSeriesData(series),
             stacking: series.stacking,
             stackId: getSeriesStackId(series),
+            valueAxis: 'y',
             dataLabels: {
                 enabled: series.dataLabels?.enabled || false,
                 style: Object.assign({}, DEFAULT_DATALABELS_STYLE, series.dataLabels?.style),

--- a/src/core/series/prepare-bar-x.ts
+++ b/src/core/series/prepare-bar-x.ts
@@ -52,6 +52,7 @@ export function prepareBarXSeries(args: PrepareBarXSeriesArgs): PreparedSeries[]
             data: prepareSeriesData(series),
             stacking: series.stacking,
             stackId: getSeriesStackId(series),
+            valueAxis: 'y',
             dataLabels: {
                 enabled: series.dataLabels?.enabled || false,
                 inside: dataLabelsInside,

--- a/src/core/series/prepare-bar-y.ts
+++ b/src/core/series/prepare-bar-y.ts
@@ -81,6 +81,7 @@ export function prepareBarYSeries(args: PrepareBarYSeriesArgs) {
                 data: prepareSeriesData(series),
                 stacking: series.stacking,
                 stackId: getSeriesStackId(series),
+                valueAxis: 'x',
                 dataLabels: await prepareDataLabels(series),
                 cursor: get(series, 'cursor', null),
                 borderRadius: series.borderRadius ?? seriesOptions?.['bar-y']?.borderRadius ?? 0,

--- a/src/core/series/types.ts
+++ b/src/core/series/types.ts
@@ -188,6 +188,7 @@ export type PreparedBarXSeries = {
     data: BarXSeriesData[];
     stackId: string;
     stacking: BarXSeries['stacking'];
+    valueAxis: 'y';
     dataLabels: {
         enabled: boolean;
         inside: boolean;
@@ -207,6 +208,7 @@ export type PreparedBarYSeries = {
     data: BarYSeriesData[];
     stackId: string;
     stacking: BarYSeries['stacking'];
+    valueAxis: 'x';
     dataLabels: {
         padding: number;
         enabled: boolean;
@@ -313,6 +315,7 @@ export type PreparedAreaSeries = {
     data: AreaSeriesData[];
     stacking: AreaSeries['stacking'];
     stackId: string;
+    valueAxis: 'y';
     lineWidth: number;
     opacity: number;
     nullMode: AreaSeries['nullMode'];

--- a/src/core/shapes/bar-y/prepare-data.ts
+++ b/src/core/shapes/bar-y/prepare-data.ts
@@ -137,10 +137,6 @@ export async function prepareBarYData(args: {
                 const borderWidth = barSize > s.borderWidth * 2 ? s.borderWidth : 0;
                 const isFirstInStack = xValueIndex === 0;
                 const isLastStackItem = xValueIndex === sortedData.length - 1;
-                // Whether the bar extends toward higher pixel coords from base.
-                // Depends on both data sign and axis order (e.g. reverse). Doing
-                // the comparison in pixel space keeps it correct under zoom too,
-                // where range[0] is no longer 0 due to zoom padding.
                 const extendsRight = xLinearScale(xValue) > baseValue;
                 // Calculate position with border compensation
                 // Border extends halfBorder outward from the shape, so we need to adjust position

--- a/src/core/shapes/bar-y/prepare-data.ts
+++ b/src/core/shapes/bar-y/prepare-data.ts
@@ -42,7 +42,6 @@ export async function prepareBarYData(args: {
     const stackGap = seriesOptions['bar-y'].stackGap;
     const xLinearScale = xScale as ScaleLinear<number, number>;
     const yLinearScale = yScale as ScaleLinear<number, number> | undefined;
-    const [baseRangeValue] = xLinearScale.range();
 
     if (!yLinearScale) {
         return {
@@ -138,19 +137,26 @@ export async function prepareBarYData(args: {
                 const borderWidth = barSize > s.borderWidth * 2 ? s.borderWidth : 0;
                 const isFirstInStack = xValueIndex === 0;
                 const isLastStackItem = xValueIndex === sortedData.length - 1;
+                // Whether the bar extends toward higher pixel coords from base.
+                // Depends on both data sign and axis order (e.g. reverse). Doing
+                // the comparison in pixel space keeps it correct under zoom too,
+                // where range[0] is no longer 0 due to zoom padding.
+                const extendsRight = xLinearScale(xValue) > baseValue;
                 // Calculate position with border compensation
                 // Border extends halfBorder outward from the shape, so we need to adjust position
-                let itemX = xValue > baseRangeValue ? positiveStack : negativeStack - width;
+                let itemX = extendsRight ? positiveStack : negativeStack - width;
                 itemX += itemStackGap;
                 const halfBorder = borderWidth / 2;
 
-                if (isFirstInStack && xValue > 0) {
-                    // Positive bar: border extends left, so shift position left by halfBorder
-                    // to keep the visual left edge at the zero line
+                if (isFirstInStack && extendsRight) {
+                    // Bar extends right from base, border extends outward to the
+                    // left → shift left by halfBorder to keep the visual left
+                    // edge at the zero line.
                     itemX -= halfBorder;
-                } else if (isFirstInStack && xValue < 0) {
-                    // Negative bar: border extends right, so shift position right by halfBorder
-                    // to keep the visual right edge at the zero line
+                } else if (isFirstInStack && !extendsRight && xValue !== 0) {
+                    // Bar extends left from base, border extends outward to the
+                    // right → shift right by halfBorder to keep the visual
+                    // right edge at the zero line.
                     itemX += halfBorder;
                 }
 
@@ -170,7 +176,7 @@ export async function prepareBarYData(args: {
 
                 stackItems.push(item);
 
-                if (xValue > baseRangeValue) {
+                if (extendsRight) {
                     positiveStack += width;
                 } else {
                     negativeStack -= width;

--- a/src/core/types/chart/zoom.ts
+++ b/src/core/types/chart/zoom.ts
@@ -21,8 +21,8 @@ export interface ChartZoom {
      * Supported zoom types by series type:
      * - `Area`, `Line`, `Scatter`: `x`, `y`, `xy`
      * - `BarX`: `x`, `xy`
+     * - `BarY`: `y`, `xy`
      * - `XRange`: `x`
-     * - `BarY`: `y`
      *
      * Default zoom type by series type:
      * - `BarY`: `y`

--- a/src/core/zoom/__tests__/zoom.test.ts
+++ b/src/core/zoom/__tests__/zoom.test.ts
@@ -1,0 +1,198 @@
+import type {PreparedSeries} from '../../series';
+import type {ChartXAxis, ChartYAxis} from '../../types';
+import {getZoomedSeriesData} from '../zoom';
+
+// Minimal series factories. Real `PreparedSeries` carries many extra fields,
+// but `getZoomedSeriesData` only inspects `type`, `data`, `stacking`, `yAxis`,
+// so casting these stubs to `any` is safe for the test.
+
+function barX(opts: {data: {x: string | number; y: number}[]; stacking?: 'normal' | 'percent'}) {
+    return {type: 'bar-x', data: opts.data, ...(opts.stacking ? {stacking: opts.stacking} : {})};
+}
+
+function barY(opts: {data: {x: number; y: string | number}[]; stacking?: 'normal' | 'percent'}) {
+    return {type: 'bar-y', data: opts.data, ...(opts.stacking ? {stacking: opts.stacking} : {})};
+}
+
+function area(opts: {data: {x: number; y: number}[]; stacking?: 'normal' | 'percent'}) {
+    return {type: 'area', data: opts.data, ...(opts.stacking ? {stacking: opts.stacking} : {})};
+}
+
+function categoryXAxis(categories: string[]): ChartXAxis {
+    return {type: 'category', categories} as ChartXAxis;
+}
+
+function linearXAxis(): ChartXAxis {
+    return {type: 'linear'} as ChartXAxis;
+}
+
+function linearYAxis(): ChartYAxis {
+    return {type: 'linear'} as ChartYAxis;
+}
+
+function categoryYAxis(categories: string[]): ChartYAxis {
+    return {type: 'category', categories} as ChartYAxis;
+}
+
+describe('zoom/getZoomedSeriesData', () => {
+    test('returns input unchanged when zoomState is empty', () => {
+        const series = [barX({data: [{x: 'A', y: 1}]})];
+        const result = getZoomedSeriesData({
+            seriesData: series as unknown as PreparedSeries[],
+            zoomState: {},
+        });
+        expect(result.preparedSeries).toBe(series);
+    });
+
+    describe('stacked bar-x + xy zoom', () => {
+        // bar-x: x is category (filterable), y is value (cumulative when stacked)
+        const categories = ['A', 'B', 'C', 'D'];
+        const xAxis = categoryXAxis(categories);
+        const yAxis = [linearYAxis()];
+
+        test('skips Y filter — small y values stay so the stack remains intact', () => {
+            const series = [
+                barX({stacking: 'normal', data: [{x: 'B', y: 1}]}),
+                barX({stacking: 'normal', data: [{x: 'B', y: 100}]}),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis,
+                yAxis,
+                zoomState: {x: [1, 2], y: [[50, 200]]},
+            });
+            // Without the fix the y=1 segment would be dropped (1 ∉ [50, 200])
+            // and the stack at "B" would render with only the y=100 piece.
+            expect(result.preparedSeries[0].data).toEqual([{x: 'B', y: 1}]);
+            expect(result.preparedSeries[1].data).toEqual([{x: 'B', y: 100}]);
+        });
+
+        test('still applies X filter — categories outside the zoom range are dropped', () => {
+            const series = [
+                barX({
+                    stacking: 'normal',
+                    data: [
+                        {x: 'A', y: 5},
+                        {x: 'B', y: 5},
+                        {x: 'D', y: 5},
+                    ],
+                }),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis,
+                yAxis,
+                zoomState: {x: [1, 2], y: [[0, 100]]},
+            });
+            expect(result.preparedSeries[0].data).toEqual([{x: 'B', y: 5}]);
+        });
+
+        test('non-stacked bar-x still drops points whose y is outside the zoom range', () => {
+            const series = [
+                barX({
+                    data: [
+                        {x: 'B', y: 1},
+                        {x: 'B', y: 100},
+                    ],
+                }),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis,
+                yAxis,
+                zoomState: {x: [1, 2], y: [[50, 200]]},
+            });
+            expect(result.preparedSeries[0].data).toEqual([{x: 'B', y: 100}]);
+        });
+    });
+
+    describe('stacked bar-y + xy zoom', () => {
+        // bar-y: x is value (cumulative when stacked), y is category
+        const categories = ['2007', '2008', '2009'];
+        const xAxis = linearXAxis();
+        const yAxis = [categoryYAxis(categories)];
+
+        test('skips X filter — small x contributions stay so the stack remains intact', () => {
+            const series = [
+                barY({stacking: 'normal', data: [{x: 1, y: '2007'}]}),
+                barY({stacking: 'normal', data: [{x: 80, y: '2007'}]}),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis,
+                yAxis,
+                zoomState: {x: [78, 92], y: [[0, 0]]},
+            });
+            // Both segments must survive — without the fix x=1 (or x=80, since
+            // 80 ∈ [78, 92] but 1 ∉) would be filtered and the cumulative
+            // stack would re-anchor from 0 instead of from the previous sum.
+            expect(result.preparedSeries[0].data).toEqual([{x: 1, y: '2007'}]);
+            expect(result.preparedSeries[1].data).toEqual([{x: 80, y: '2007'}]);
+        });
+
+        test('still applies Y filter — categories outside the zoom range are dropped', () => {
+            const series = [
+                barY({
+                    stacking: 'normal',
+                    data: [
+                        {x: 50, y: '2007'},
+                        {x: 50, y: '2008'},
+                        {x: 50, y: '2009'},
+                    ],
+                }),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis,
+                yAxis,
+                zoomState: {x: [0, 100], y: [[0, 1]]},
+            });
+            expect(result.preparedSeries[0].data).toEqual([
+                {x: 50, y: '2007'},
+                {x: 50, y: '2008'},
+            ]);
+        });
+
+        test('non-stacked bar-y still drops points whose x is outside the zoom range', () => {
+            const series = [
+                barY({
+                    data: [
+                        {x: 1, y: '2007'},
+                        {x: 80, y: '2007'},
+                    ],
+                }),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis,
+                yAxis,
+                zoomState: {x: [78, 92], y: [[0, 0]]},
+            });
+            expect(result.preparedSeries[0].data).toEqual([{x: 80, y: '2007'}]);
+        });
+    });
+
+    describe('stacked area + y zoom', () => {
+        test('skips Y filter — small y values stay so the cumulative stack stays intact', () => {
+            const series = [
+                area({
+                    stacking: 'normal',
+                    data: [
+                        {x: 1, y: 1},
+                        {x: 2, y: 100},
+                    ],
+                }),
+            ];
+            const result = getZoomedSeriesData({
+                seriesData: series as unknown as PreparedSeries[],
+                xAxis: linearXAxis(),
+                yAxis: [linearYAxis()],
+                zoomState: {y: [[50, 200]]},
+            });
+            expect(result.preparedSeries[0].data).toEqual([
+                {x: 1, y: 1},
+                {x: 2, y: 100},
+            ]);
+        });
+    });
+});

--- a/src/core/zoom/__tests__/zoom.test.ts
+++ b/src/core/zoom/__tests__/zoom.test.ts
@@ -3,19 +3,34 @@ import type {ChartXAxis, ChartYAxis} from '../../types';
 import {getZoomedSeriesData} from '../zoom';
 
 // Minimal series factories. Real `PreparedSeries` carries many extra fields,
-// but `getZoomedSeriesData` only inspects `type`, `data`, `stacking`, `yAxis`,
-// so casting these stubs to `any` is safe for the test.
+// but `getZoomedSeriesData` only inspects `type`, `data`, `stacking`,
+// `valueAxis`, `yAxis`, so casting these stubs to `any` is safe for the test.
 
 function barX(opts: {data: {x: string | number; y: number}[]; stacking?: 'normal' | 'percent'}) {
-    return {type: 'bar-x', data: opts.data, ...(opts.stacking ? {stacking: opts.stacking} : {})};
+    return {
+        type: 'bar-x',
+        data: opts.data,
+        valueAxis: 'y',
+        ...(opts.stacking ? {stacking: opts.stacking} : {}),
+    };
 }
 
 function barY(opts: {data: {x: number; y: string | number}[]; stacking?: 'normal' | 'percent'}) {
-    return {type: 'bar-y', data: opts.data, ...(opts.stacking ? {stacking: opts.stacking} : {})};
+    return {
+        type: 'bar-y',
+        data: opts.data,
+        valueAxis: 'x',
+        ...(opts.stacking ? {stacking: opts.stacking} : {}),
+    };
 }
 
 function area(opts: {data: {x: number; y: number}[]; stacking?: 'normal' | 'percent'}) {
-    return {type: 'area', data: opts.data, ...(opts.stacking ? {stacking: opts.stacking} : {})};
+    return {
+        type: 'area',
+        data: opts.data,
+        valueAxis: 'y',
+        ...(opts.stacking ? {stacking: opts.stacking} : {}),
+    };
 }
 
 function categoryXAxis(categories: string[]): ChartXAxis {

--- a/src/core/zoom/zoom.ts
+++ b/src/core/zoom/zoom.ts
@@ -99,17 +99,14 @@ export function getZoomedSeriesData(args: {
         }
 
         // For stacked series the chart-space position of each point is the
-        // cumulative stack sum, not its individual value. Filtering by the
-        // raw point value would drop segments that still need to participate
-        // in the stack, so skip the value-axis filter and let the axis range
-        // / clip handle visibility:
-        //   - bar-x, area  → value axis is Y, skip Y filter
-        //   - bar-y        → value axis is X, skip X filter
+        // cumulative stack sum, not its individual value, so the value-axis
+        // filter would drop segments that still need to participate in the
+        // stack. Skip it and let the axis range / clip handle visibility.
         const isStacked = 'stacking' in seriesItem && Boolean(seriesItem.stacking);
-        const skipYFilter =
-            isStacked &&
-            (seriesItem.type === SERIES_TYPE.BarX || seriesItem.type === SERIES_TYPE.Area);
-        const skipXFilter = isStacked && seriesItem.type === SERIES_TYPE.BarY;
+        const stackedValueAxis =
+            isStacked && 'valueAxis' in seriesItem ? seriesItem.valueAxis : undefined;
+        const skipXFilter = stackedValueAxis === 'x';
+        const skipYFilter = stackedValueAxis === 'y';
 
         seriesItem.data.forEach((point, i) => {
             const prevPoint = seriesItem.data[i - 1];

--- a/src/core/zoom/zoom.ts
+++ b/src/core/zoom/zoom.ts
@@ -98,6 +98,19 @@ export function getZoomedSeriesData(args: {
             return;
         }
 
+        // For stacked series the chart-space position of each point is the
+        // cumulative stack sum, not its individual value. Filtering by the
+        // raw point value would drop segments that still need to participate
+        // in the stack, so skip the value-axis filter and let the axis range
+        // / clip handle visibility:
+        //   - bar-x, area  → value axis is Y, skip Y filter
+        //   - bar-y        → value axis is X, skip X filter
+        const isStacked = 'stacking' in seriesItem && Boolean(seriesItem.stacking);
+        const skipYFilter =
+            isStacked &&
+            (seriesItem.type === SERIES_TYPE.BarX || seriesItem.type === SERIES_TYPE.Area);
+        const skipXFilter = isStacked && seriesItem.type === SERIES_TYPE.BarY;
+
         seriesItem.data.forEach((point, i) => {
             const prevPoint = seriesItem.data[i - 1];
             const isFirstPoint = i === 0;
@@ -106,7 +119,7 @@ export function getZoomedSeriesData(args: {
 
             prevPointInRange = currentPointInRange;
 
-            if (zoomState.x) {
+            if (zoomState.x && !skipXFilter) {
                 const [xMin, xMax] = zoomState.x;
                 if ('x0' in point && 'x1' in point) {
                     const isStartInRange = isValueInRange({
@@ -133,7 +146,7 @@ export function getZoomedSeriesData(args: {
                 }
             }
 
-            if (zoomState.y) {
+            if (zoomState.y && !skipYFilter) {
                 const yAxisIndex =
                     'yAxis' in seriesItem && typeof seriesItem.yAxis === 'number'
                         ? seriesItem.yAxis


### PR DESCRIPTION
## Problem                                                                                                                        
                                                                                                                                    
  Stacked series under XY zoom rendered incorrectly — segments were lost or anchored to wrong stack positions. Two independent bugs:
                                                                                                                                    
  **1. Per-point value-axis filter dropped stack segments.** `getZoomedSeriesData` checks each point's individual value against the zoom range. For stacked series the chart-space position of a segment is the *cumulative* stack sum, not the raw `point.x` / `point.y`, so segments with small individual values fell outside the zoom range and got dropped — leaving the remaining ones to re-anchor from zero.                                                                                                              
                                                                                                                                    
  **2. `prepareBarYData` direction check used pixel coords as data sign.** The "positive or negative side of base?" branch was `xValue > xLinearScale.range()[0]`. Without zoom `range[0] = 0`, so it accidentally worked as `xValue > 0`. With zoom, `getXScaleRange` adds 2% padding and `range[0]` becomes `0.02·boundsWidth`. Any positive value smaller than that padding got misclassified into `negativeStack` and rendered far off-canvas left.                                                              
   
  ## Fix                                                                                                                            
                  
  `src/core/zoom/zoom.ts` — skip the value-axis filter for stacked series:
                                          
  - `bar-x`, `area` → value axis is Y, skip Y filter
  - `bar-y` → value axis is X, skip X filter