### PR TITLE
refactor(tooltip): distribute getClosestData logic into per-series files

### DIFF
--- a/src/core/shapes/area/get-tooltip-data.ts
+++ b/src/core/shapes/area/get-tooltip-data.ts
@@ -1,0 +1,30 @@
+import type {AreaSeries} from '../../../types';
+import type {
+    GetTooltipDataArgs,
+    GetTooltipDataResult,
+    ShapePoint,
+} from '../../utils/tooltip-helpers';
+
+import type {PreparedAreaData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedAreaData>): GetTooltipDataResult {
+    const {data} = args;
+
+    const xLookupPoints = data.reduce<ShapePoint[]>((acc, d) => {
+        for (const p of d.points) {
+            if (p.y === null || p.hiddenInLine) {
+                continue;
+            }
+            acc.push({
+                data: p.data,
+                series: p.series as AreaSeries,
+                x: p.x,
+                y0: p.y0,
+                y1: p.y,
+            });
+        }
+        return acc;
+    }, []);
+
+    return {chunks: [], xLookupPoints};
+}

--- a/src/core/shapes/bar-x/get-tooltip-data.ts
+++ b/src/core/shapes/bar-x/get-tooltip-data.ts
@@ -1,0 +1,33 @@
+import groupBy from 'lodash/groupBy';
+
+import type {BarXSeries} from '../../../types';
+import type {
+    GetTooltipDataArgs,
+    GetTooltipDataResult,
+    ShapePoint,
+} from '../../utils/tooltip-helpers';
+
+import type {PreparedBarXData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedBarXData>): GetTooltipDataResult {
+    const {data} = args;
+
+    const barXGroups = groupBy(data, (d) => String(d.data.x));
+    const xLookupPoints: ShapePoint[] = [];
+
+    for (const group of Object.values(barXGroups)) {
+        const groupCenterX = group.reduce((sum, d) => sum + d.x + d.width / 2, 0) / group.length;
+        for (const d of group) {
+            xLookupPoints.push({
+                data: d.data,
+                series: d.series as BarXSeries,
+                x: groupCenterX,
+                y0: d.y,
+                y1: d.y + d.height,
+                sourceX: d.x + d.width / 2,
+            });
+        }
+    }
+
+    return {chunks: [], xLookupPoints};
+}

--- a/src/core/shapes/bar-y/get-tooltip-data.ts
+++ b/src/core/shapes/bar-y/get-tooltip-data.ts
@@ -1,0 +1,50 @@
+import {bisector, sort} from 'd3-array';
+
+import type {TooltipDataChunk} from '../../../types';
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedBarYData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedBarYData>): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const sorted = sort(data, (p) => p.y);
+    const closestYIndex = bisector<PreparedBarYData, number>((p) => p.y + p.height / 2).center(
+        sorted,
+        pointerY,
+    );
+
+    const closestYPoint = sorted[closestYIndex];
+
+    if (!closestYPoint) {
+        return {chunks: []};
+    }
+
+    const selectedPoints = data.filter((p) => p.data.y === closestYPoint.data.y);
+
+    const closestPoints = sort(
+        selectedPoints.filter((p) => p.y === closestYPoint.y),
+        (p) => p.x,
+    );
+
+    let closestPointXValue: number | undefined;
+    const lastPoint = closestPoints[closestPoints.length - 1];
+    if (pointerX < closestPoints[0]?.x) {
+        closestPointXValue = closestPoints[0].x;
+    } else if (lastPoint && pointerX > lastPoint.x + lastPoint.width) {
+        closestPointXValue = lastPoint.x;
+    } else {
+        closestPointXValue = closestPoints.find(
+            (p) => pointerX > p.x && pointerX < p.x + p.width,
+        )?.x;
+    }
+
+    return {
+        chunks: selectedPoints.map((p) => ({
+            data: p.data,
+            series: p.series,
+            closest: p.x === closestPointXValue && p.y === closestYPoint.y,
+        })) as TooltipDataChunk[],
+    };
+}

--- a/src/core/shapes/funnel/get-tooltip-data.ts
+++ b/src/core/shapes/funnel/get-tooltip-data.ts
@@ -1,0 +1,30 @@
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedFunnelData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedFunnelData>): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const closestPoint = data[0]?.items.find(
+        (item) =>
+            pointerX >= item.x &&
+            pointerX <= item.x + item.width &&
+            pointerY >= item.y &&
+            pointerY <= item.y + item.height,
+    );
+
+    if (!closestPoint) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: [
+            {
+                data: closestPoint.data,
+                series: closestPoint.series,
+                closest: true,
+            },
+        ],
+    };
+}

--- a/src/core/shapes/heatmap/get-tooltip-data.ts
+++ b/src/core/shapes/heatmap/get-tooltip-data.ts
@@ -1,0 +1,33 @@
+import type {HeatmapSeries} from '../../../types';
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedHeatmapData} from './types';
+
+export function getTooltipData(
+    args: GetTooltipDataArgs<PreparedHeatmapData>,
+): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const closestPoint = data[0]?.items.find(
+        (cell) =>
+            pointerX >= cell.x &&
+            pointerX <= cell.x + cell.width &&
+            pointerY >= cell.y &&
+            pointerY <= cell.y + cell.height,
+    );
+
+    if (!closestPoint) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: [
+            {
+                data: closestPoint.data,
+                series: data[0].series as unknown as HeatmapSeries,
+                closest: true,
+            },
+        ],
+    };
+}

--- a/src/core/shapes/line/get-tooltip-data.ts
+++ b/src/core/shapes/line/get-tooltip-data.ts
@@ -1,0 +1,29 @@
+import type {LineSeries} from '../../../types';
+import type {
+    GetTooltipDataArgs,
+    GetTooltipDataResult,
+    ShapePoint,
+} from '../../utils/tooltip-helpers';
+
+import type {PreparedLineData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedLineData>): GetTooltipDataResult {
+    const {data} = args;
+
+    const xLookupPoints = data.reduce<ShapePoint[]>((acc, d) => {
+        for (const p of d.points) {
+            if (p.y !== null && p.x !== null && !p.hiddenInLine) {
+                acc.push({
+                    data: p.data,
+                    series: p.series as LineSeries,
+                    x: p.x,
+                    y0: p.y,
+                    y1: p.y,
+                });
+            }
+        }
+        return acc;
+    }, []);
+
+    return {chunks: [], xLookupPoints};
+}

--- a/src/core/shapes/pie/get-tooltip-data.ts
+++ b/src/core/shapes/pie/get-tooltip-data.ts
@@ -1,0 +1,35 @@
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+import {getRadius} from '../../utils/tooltip-helpers';
+
+import type {PreparedPieData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedPieData>): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const points = data.flatMap((d) => d.segments);
+    const closestPoint = points.find((p) => {
+        const {center} = p.data.pie;
+        const x = pointerX - center[0];
+        const y = pointerY - center[1];
+        let angle = Math.atan2(y, x) + 0.5 * Math.PI;
+        angle = angle < 0 ? Math.PI * 2 + angle : angle;
+        const polarRadius = getRadius({center, pointer: [pointerX, pointerY]});
+
+        return angle >= p.startAngle && angle <= p.endAngle && polarRadius < p.data.radius;
+    });
+
+    if (!closestPoint) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: [
+            {
+                data: closestPoint.data.series.data,
+                series: closestPoint.data.series,
+                closest: true,
+            },
+        ],
+    };
+}

--- a/src/core/shapes/radar/get-tooltip-data.ts
+++ b/src/core/shapes/radar/get-tooltip-data.ts
@@ -1,0 +1,53 @@
+import {Delaunay} from 'd3-delaunay';
+
+import type {RadarSeries} from '../../../types';
+import {getRadius, isInsidePath} from '../../utils/tooltip-helpers';
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedRadarData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedRadarData>): GetTooltipDataResult {
+    const {data, position, boundsWidth, boundsHeight} = args;
+    const [pointerX, pointerY] = position;
+
+    const [radarData] = data;
+    if (!radarData) {
+        return {chunks: []};
+    }
+
+    const radius = getRadius({center: radarData.center, pointer: [pointerX, pointerY]});
+    if (radius > radarData.radius) {
+        return {chunks: []};
+    }
+
+    const radarShapes = radarData.shapes.filter((shape) =>
+        isInsidePath({
+            path: shape.path,
+            point: [pointerX, pointerY],
+            width: boundsWidth,
+            height: boundsHeight,
+            strokeWidth: shape.borderWidth,
+        }),
+    );
+
+    const points = radarShapes.flatMap((shape) => shape.points);
+    const delaunay = Delaunay.from(
+        points,
+        (d) => d.position[0],
+        (d) => d.position[1],
+    );
+    const closestPoint = points[delaunay.find(pointerX, pointerY)];
+
+    if (!closestPoint) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: radarData.shapes.map((shape) => ({
+            data: shape.points[closestPoint.index].data,
+            series: shape.series as RadarSeries,
+            category: shape.series.categories[closestPoint.index],
+            closest: shape.series === closestPoint.series,
+        })),
+    };
+}

--- a/src/core/shapes/sankey/get-tooltip-data.ts
+++ b/src/core/shapes/sankey/get-tooltip-data.ts
@@ -1,0 +1,40 @@
+import type {SankeySeries, SankeySeriesData} from '../../../types';
+import {isInsidePath} from '../../utils/tooltip-helpers';
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedSankeyData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedSankeyData>): GetTooltipDataResult {
+    const {data, position, boundsWidth, boundsHeight} = args;
+    const [pointerX, pointerY] = position;
+
+    const [sankeyData] = data;
+    if (!sankeyData) {
+        return {chunks: []};
+    }
+
+    const closestLink = sankeyData.links.find((d) =>
+        isInsidePath({
+            path: d.path ?? '',
+            strokeWidth: d.strokeWidth,
+            point: [pointerX, pointerY],
+            width: boundsWidth,
+            height: boundsHeight,
+        }),
+    );
+
+    if (!closestLink) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: [
+            {
+                data: closestLink.source as SankeySeriesData,
+                target: closestLink.target,
+                series: sankeyData.series as SankeySeries,
+                closest: true,
+            },
+        ],
+    };
+}

--- a/src/core/shapes/scatter/get-tooltip-data.ts
+++ b/src/core/shapes/scatter/get-tooltip-data.ts
@@ -1,0 +1,33 @@
+import {Delaunay} from 'd3-delaunay';
+
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedScatterData} from './types';
+
+export function getTooltipData(
+    args: GetTooltipDataArgs<PreparedScatterData>,
+): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const delaunay = Delaunay.from(
+        data,
+        (d) => d.point.x,
+        (d) => d.point.y,
+    );
+    const closestPoint = data[delaunay.find(pointerX, pointerY)];
+
+    if (!closestPoint) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: [
+            {
+                data: closestPoint.point.data,
+                series: closestPoint.point.series,
+                closest: true,
+            },
+        ],
+    };
+}

--- a/src/core/shapes/treemap/get-tooltip-data.ts
+++ b/src/core/shapes/treemap/get-tooltip-data.ts
@@ -1,0 +1,29 @@
+import type {TreemapSeries} from '../../../types';
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedTreemapData} from './types';
+
+export function getTooltipData(
+    args: GetTooltipDataArgs<PreparedTreemapData>,
+): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const closestPoint = data[0]?.leaves.find(
+        (l) => pointerX >= l.x0 && pointerX <= l.x1 && pointerY >= l.y0 && pointerY <= l.y1,
+    );
+
+    if (!closestPoint) {
+        return {chunks: []};
+    }
+
+    return {
+        chunks: [
+            {
+                data: closestPoint.data,
+                series: data[0].series as unknown as TreemapSeries,
+                closest: true,
+            },
+        ],
+    };
+}

--- a/src/core/shapes/waterfall/get-tooltip-data.ts
+++ b/src/core/shapes/waterfall/get-tooltip-data.ts
@@ -1,0 +1,29 @@
+import type {TooltipDataChunk, WaterfallSeries, WaterfallSeriesData} from '../../../types';
+import {getClosestPointsByXValue} from '../../utils/tooltip-helpers';
+import type {
+    GetTooltipDataArgs,
+    GetTooltipDataResult,
+    ShapePoint,
+} from '../../utils/tooltip-helpers';
+
+import type {PreparedWaterfallData} from './types';
+
+export function getTooltipData(
+    args: GetTooltipDataArgs<PreparedWaterfallData>,
+): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const points = data.map<ShapePoint>((d) => ({
+        data: d.data as WaterfallSeriesData,
+        series: d.series as WaterfallSeries,
+        x: d.x + d.width / 2,
+        y0: d.y,
+        y1: d.y + d.height,
+        subTotal: d.subTotal,
+    }));
+
+    const chunks = getClosestPointsByXValue(pointerX, pointerY, points) as TooltipDataChunk[];
+
+    return {chunks};
+}

--- a/src/core/shapes/x-range/get-tooltip-data.ts
+++ b/src/core/shapes/x-range/get-tooltip-data.ts
@@ -1,0 +1,36 @@
+import {sort} from 'd3-array';
+
+import type {XRangeSeries} from '../../../types';
+import type {GetTooltipDataArgs, GetTooltipDataResult} from '../../utils/tooltip-helpers';
+
+import type {PreparedXRangeData} from './types';
+
+export function getTooltipData(args: GetTooltipDataArgs<PreparedXRangeData>): GetTooltipDataResult {
+    const {data, position} = args;
+    const [pointerX, pointerY] = position;
+
+    const pointsInRange = data.filter(
+        (d) =>
+            pointerX >= d.x &&
+            pointerX <= d.x + d.width &&
+            pointerY >= d.y &&
+            pointerY <= d.y + d.height,
+    );
+
+    if (pointsInRange.length === 0) {
+        return {chunks: []};
+    }
+
+    const closestByX =
+        pointsInRange.length === 1
+            ? pointsInRange[0]
+            : sort(pointsInRange, (d) => Math.abs(d.x + d.width / 2 - pointerX))[0];
+
+    return {
+        chunks: pointsInRange.map((d) => ({
+            data: d.data,
+            series: d.series as unknown as XRangeSeries,
+            closest: d === closestByX,
+        })),
+    };
+}

--- a/src/core/utils/get-closest-data.ts
+++ b/src/core/utils/get-closest-data.ts
@@ -1,38 +1,24 @@
-import {bisector, sort} from 'd3-array';
-import {Delaunay} from 'd3-delaunay';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
 
 import type {ShapeData} from '../../hooks/useShapes';
-import type {
-    AreaSeries,
-    BarXSeries,
-    ChartSeries,
-    ChartSeriesData,
-    HeatmapSeries,
-    LineSeries,
-    RadarSeries,
-    SankeySeries,
-    SankeySeriesData,
-    TooltipDataChunk,
-    TreemapSeries,
-    WaterfallSeries,
-    WaterfallSeriesData,
-    XRangeSeries,
-} from '../../types';
-import type {PreparedAreaData} from '../shapes/area/types';
-import type {PreparedBarXData} from '../shapes/bar-x/types';
-import type {PreparedBarYData} from '../shapes/bar-y/types';
-import type {PreparedFunnelData} from '../shapes/funnel/types';
-import type {PreparedHeatmapData} from '../shapes/heatmap/types';
-import type {PreparedLineData} from '../shapes/line/types';
-import type {PreparedPieData} from '../shapes/pie/types';
-import type {PreparedRadarData} from '../shapes/radar/types';
-import type {PreparedSankeyData} from '../shapes/sankey/types';
-import type {PreparedScatterData} from '../shapes/scatter/types';
-import type {PreparedTreemapData} from '../shapes/treemap/types';
-import type {PreparedWaterfallData} from '../shapes/waterfall/types';
-import type {PreparedXRangeData} from '../shapes/x-range/types';
+import type {TooltipDataChunk} from '../../types';
+import {getTooltipData as areaGetTooltipData} from '../shapes/area/get-tooltip-data';
+import {getTooltipData as barXGetTooltipData} from '../shapes/bar-x/get-tooltip-data';
+import {getTooltipData as barYGetTooltipData} from '../shapes/bar-y/get-tooltip-data';
+import {getTooltipData as funnelGetTooltipData} from '../shapes/funnel/get-tooltip-data';
+import {getTooltipData as heatmapGetTooltipData} from '../shapes/heatmap/get-tooltip-data';
+import {getTooltipData as lineGetTooltipData} from '../shapes/line/get-tooltip-data';
+import {getTooltipData as pieGetTooltipData} from '../shapes/pie/get-tooltip-data';
+import {getTooltipData as radarGetTooltipData} from '../shapes/radar/get-tooltip-data';
+import {getTooltipData as sankeyGetTooltipData} from '../shapes/sankey/get-tooltip-data';
+import {getTooltipData as scatterGetTooltipData} from '../shapes/scatter/get-tooltip-data';
+import {getTooltipData as treemapGetTooltipData} from '../shapes/treemap/get-tooltip-data';
+import {getTooltipData as waterfallGetTooltipData} from '../shapes/waterfall/get-tooltip-data';
+import {getTooltipData as xRangeGetTooltipData} from '../shapes/x-range/get-tooltip-data';
+
+import {getClosestPointsByXValue} from './tooltip-helpers';
+import type {GetTooltipDataFn, ShapePoint} from './tooltip-helpers';
 
 type GetClosestPointsArgs = {
     position: [number, number];
@@ -41,88 +27,21 @@ type GetClosestPointsArgs = {
     boundsWidth: number;
 };
 
-export type ShapePoint = {
-    x: number;
-    y0: number;
-    y1: number;
-    data: ChartSeriesData;
-    series: ChartSeries;
-    subTotal?: number;
-    sourceX?: number;
+const tooltipFnByType: Record<string, GetTooltipDataFn> = {
+    line: lineGetTooltipData,
+    area: areaGetTooltipData,
+    'bar-x': barXGetTooltipData,
+    'bar-y': barYGetTooltipData,
+    waterfall: waterfallGetTooltipData,
+    scatter: scatterGetTooltipData,
+    pie: pieGetTooltipData,
+    treemap: treemapGetTooltipData,
+    heatmap: heatmapGetTooltipData,
+    sankey: sankeyGetTooltipData,
+    radar: radarGetTooltipData,
+    funnel: funnelGetTooltipData,
+    'x-range': xRangeGetTooltipData,
 };
-
-function getClosestYIndex(items: ShapePoint[], y: number) {
-    let closestYIndex = -1;
-    if (y < items[0]?.y0) {
-        closestYIndex = 0;
-    } else if (y > items[items.length - 1]?.y1) {
-        closestYIndex = items.length - 1;
-    } else {
-        closestYIndex = items.findIndex((p) => y > p.y0 && y < p.y1);
-        if (closestYIndex === -1) {
-            const sortedY = sort(
-                items.map((p, index) => ({index, y: p.y1 + (p.y0 - p.y1) / 2})),
-                (p) => p.y,
-            );
-            const sortedYIndex = bisector<{y: number}, number>((p) => p.y).center(sortedY, y);
-            closestYIndex = sortedY[sortedYIndex]?.index ?? -1;
-        }
-    }
-
-    return closestYIndex;
-}
-
-function getClosestPointsByXValue(x: number, y: number, points: ShapePoint[]) {
-    const sorted = sort(points, (p) => p.x);
-    const closestXIndex = bisector<ShapePoint, number>((p) => p.x).center(sorted, x);
-
-    if (sorted.length === 0 || closestXIndex === -1) {
-        return [];
-    }
-
-    const closestX = Math.round(sorted[closestXIndex].x);
-    const filtered = points.filter((p) => Math.round(p.x) === closestX);
-
-    const groupedBySeries = Object.values(groupBy(filtered, (p) => get(p.series, 'id'))).map(
-        (items) => {
-            const sortedByY = sort(items, (p) => p.y0);
-            const index = getClosestYIndex(sortedByY, y);
-            return sortedByY[index === -1 ? 0 : index];
-        },
-    );
-
-    const closestPoints = sort(groupedBySeries, (p) => p.y0);
-
-    const pointsWithSourceX = closestPoints.filter((p) => p.sourceX !== undefined);
-    const uniqueSourceX = new Set(pointsWithSourceX.map((p) => p.sourceX));
-
-    if (pointsWithSourceX.length > 1 && uniqueSourceX.size > 1) {
-        const sortedBySourceX = sort(pointsWithSourceX, (p) => p.sourceX ?? 0);
-        const closestSourceXIdx = bisector<ShapePoint, number>((p) => p.sourceX ?? 0).center(
-            sortedBySourceX,
-            x,
-        );
-        const closestSourceX = sortedBySourceX[closestSourceXIdx]?.sourceX;
-
-        const candidates = closestPoints.filter(
-            (p) => p.sourceX === undefined || p.sourceX === closestSourceX,
-        );
-        const sortedCandidates = sort(candidates, (p) => p.y0);
-        const winnerIdx = getClosestYIndex(sortedCandidates, y);
-        const winner = sortedCandidates[winnerIdx === -1 ? 0 : winnerIdx];
-
-        return closestPoints.map((p) => ({
-            ...p,
-            closest: p === winner,
-        }));
-    }
-
-    const closestYIndex = getClosestYIndex(closestPoints, y);
-    return closestPoints.map((p, i) => ({
-        ...p,
-        closest: i === closestYIndex,
-    }));
-}
 
 function getSeriesType(shapeData: ShapeData) {
     return (
@@ -132,363 +51,40 @@ function getSeriesType(shapeData: ShapeData) {
     );
 }
 
+export type {ShapePoint} from './tooltip-helpers';
+
 export function getClosestPoints(args: GetClosestPointsArgs): TooltipDataChunk[] {
     const {position, shapesData, boundsHeight, boundsWidth} = args;
     const [pointerX, pointerY] = position;
 
     const result: TooltipDataChunk[] = [];
+    const xLookupPoints: ShapePoint[] = [];
     const groups = groupBy(shapesData, getSeriesType);
 
-    const closestPointsByXValue: ShapePoint[] = [];
-
-    Object.entries(groups).forEach(([seriesType, list]) => {
-        switch (seriesType) {
-            case 'line': {
-                const linePoints = (list as PreparedLineData[]).reduce<ShapePoint[]>((acc, d) => {
-                    acc.push(
-                        ...d.points.reduce<ShapePoint[]>((accPoints, p) => {
-                            if (p.y !== null && p.x !== null && !p.hiddenInLine) {
-                                accPoints.push({
-                                    data: p.data,
-                                    series: p.series as LineSeries,
-                                    x: p.x,
-                                    y0: p.y,
-                                    y1: p.y,
-                                });
-                            }
-                            return accPoints;
-                        }, []),
-                    );
-                    return acc;
-                }, []);
-                closestPointsByXValue.push(...linePoints);
-                break;
-            }
-            case 'area': {
-                const areaPoints = (list as PreparedAreaData[]).reduce<ShapePoint[]>((acc, d) => {
-                    for (const p of d.points) {
-                        if (p.y === null || p.hiddenInLine) {
-                            continue;
-                        }
-                        acc.push({
-                            data: p.data,
-                            series: p.series as AreaSeries,
-                            x: p.x,
-                            y0: p.y0,
-                            y1: p.y,
-                        });
-                    }
-                    return acc;
-                }, []);
-                closestPointsByXValue.push(...areaPoints);
-                break;
-            }
-            case 'bar-x': {
-                const barXList = list as PreparedBarXData[];
-                const barXGroups = groupBy(barXList, (d) => String(d.data.x));
-                const barXPoints: ShapePoint[] = [];
-                Object.values(barXGroups).forEach((group) => {
-                    const groupCenterX =
-                        group.reduce((sum, d) => sum + d.x + d.width / 2, 0) / group.length;
-                    group.forEach((d) => {
-                        barXPoints.push({
-                            data: d.data,
-                            series: d.series as BarXSeries,
-                            x: groupCenterX,
-                            y0: d.y,
-                            y1: d.y + d.height,
-                            sourceX: d.x + d.width / 2,
-                        });
-                    });
-                });
-                closestPointsByXValue.push(...barXPoints);
-                break;
-            }
-            case 'waterfall': {
-                const points = (list as PreparedWaterfallData[]).map<ShapePoint>((d) => ({
-                    data: d.data as WaterfallSeriesData,
-                    series: d.series as WaterfallSeries,
-                    x: d.x + d.width / 2,
-                    y0: d.y,
-                    y1: d.y + d.height,
-                    subTotal: d.subTotal,
-                }));
-                result.push(
-                    ...(getClosestPointsByXValue(pointerX, pointerY, points) as TooltipDataChunk[]),
-                );
-
-                break;
-            }
-            case 'bar-y': {
-                const points = list as PreparedBarYData[];
-                const sorted = sort(points, (p) => p.y);
-                const closestYIndex = bisector<PreparedBarYData, number>(
-                    (p) => p.y + p.height / 2,
-                ).center(sorted, pointerY);
-
-                const closestYPoint = sorted[closestYIndex];
-
-                let selectedPoints: PreparedBarYData[] = [];
-                let closestPointXValue: number | undefined = -1;
-                if (closestYPoint) {
-                    selectedPoints = points.filter((p) => p.data.y === closestYPoint.data.y);
-
-                    const closestPoints = sort(
-                        selectedPoints.filter((p) => p.y === closestYPoint.y),
-                        (p) => p.x,
-                    );
-
-                    const lastPoint = closestPoints[closestPoints.length - 1];
-                    if (pointerX < closestPoints[0]?.x) {
-                        closestPointXValue = closestPoints[0].x;
-                    } else if (lastPoint && pointerX > lastPoint.x + lastPoint.width) {
-                        closestPointXValue = lastPoint.x;
-                    } else {
-                        closestPointXValue = closestPoints.find(
-                            (p) => pointerX > p.x && pointerX < p.x + p.width,
-                        )?.x;
-                    }
-                }
-
-                result.push(
-                    ...(selectedPoints.map((p) => ({
-                        data: p.data,
-                        series: p.series,
-                        closest: p.x === closestPointXValue && p.y === closestYPoint.y,
-                    })) as TooltipDataChunk[]),
-                );
-                break;
-            }
-            case 'scatter': {
-                const points = list as PreparedScatterData[];
-                const delaunayX = Delaunay.from(
-                    points,
-                    (d) => d.point.x,
-                    (d) => d.point.y,
-                );
-                const closestPoint = points[delaunayX.find(pointerX, pointerY)];
-                if (closestPoint) {
-                    result.push({
-                        data: closestPoint.point.data,
-                        series: closestPoint.point.series,
-                        closest: true,
-                    });
-                }
-
-                break;
-            }
-            case 'pie': {
-                const points = (list as PreparedPieData[]).map((d) => d.segments).flat();
-                const closestPoint = points.find((p) => {
-                    const {center} = p.data.pie;
-                    const x = pointerX - center[0];
-                    const y = pointerY - center[1];
-                    let angle = Math.atan2(y, x) + 0.5 * Math.PI;
-                    angle = angle < 0 ? Math.PI * 2 + angle : angle;
-                    const polarRadius = getRadius({center, pointer: [pointerX, pointerY]});
-
-                    return (
-                        angle >= p.startAngle && angle <= p.endAngle && polarRadius < p.data.radius
-                    );
-                });
-
-                if (closestPoint) {
-                    result.push({
-                        data: closestPoint.data.series.data,
-                        series: closestPoint.data.series,
-                        closest: true,
-                    });
-                }
-
-                break;
-            }
-            case 'treemap': {
-                const data = list as unknown as PreparedTreemapData[];
-                const closestPoint = data[0]?.leaves.find((l) => {
-                    return (
-                        pointerX >= l.x0 && pointerX <= l.x1 && pointerY >= l.y0 && pointerY <= l.y1
-                    );
-                });
-                if (closestPoint) {
-                    result.push({
-                        data: closestPoint.data,
-                        series: data[0].series as unknown as TreemapSeries,
-                        closest: true,
-                    });
-                }
-
-                break;
-            }
-            case 'heatmap': {
-                const data = list as unknown as PreparedHeatmapData[];
-                const closestPoint = data[0]?.items.find((cell) => {
-                    return (
-                        pointerX >= cell.x &&
-                        pointerX <= cell.x + cell.width &&
-                        pointerY >= cell.y &&
-                        pointerY <= cell.y + cell.height
-                    );
-                });
-                if (closestPoint) {
-                    result.push({
-                        data: closestPoint.data,
-                        series: data[0].series as unknown as HeatmapSeries,
-                        closest: true,
-                    });
-                }
-
-                break;
-            }
-            case 'sankey': {
-                const [data] = list as unknown as PreparedSankeyData[];
-                const closestLink = data.links.find((d) => {
-                    return isInsidePath({
-                        path: d.path ?? '',
-                        strokeWidth: d.strokeWidth,
-                        point: [pointerX, pointerY],
-                        width: boundsWidth,
-                        height: boundsHeight,
-                    });
-                });
-                if (closestLink) {
-                    result.push({
-                        data: closestLink.source as SankeySeriesData,
-                        target: closestLink.target,
-                        series: data.series as SankeySeries,
-                        closest: true,
-                    });
-                }
-
-                break;
-            }
-            case 'radar': {
-                const [radarData] = list as unknown as PreparedRadarData[];
-
-                const radius = getRadius({center: radarData.center, pointer: [pointerX, pointerY]});
-                if (radius <= radarData.radius) {
-                    const radarShapes = radarData.shapes.filter((shape) =>
-                        isInsidePath({
-                            path: shape.path,
-                            point: [pointerX, pointerY],
-                            width: boundsWidth,
-                            height: boundsHeight,
-                            strokeWidth: shape.borderWidth,
-                        }),
-                    );
-                    const points = radarShapes.map((shape) => shape.points).flat();
-                    const delaunayX = Delaunay.from(
-                        points,
-                        (d) => d.position[0],
-                        (d) => d.position[1],
-                    );
-                    const closestPoint = points[delaunayX.find(pointerX, pointerY)];
-                    if (closestPoint) {
-                        radarData.shapes.forEach((shape) => {
-                            result.push({
-                                data: shape.points[closestPoint.index].data,
-                                series: shape.series as RadarSeries,
-                                category: shape.series.categories[closestPoint.index],
-                                closest: shape.series === closestPoint.series,
-                            });
-                        });
-                    }
-                }
-
-                break;
-            }
-            case 'funnel': {
-                const data = list as unknown as PreparedFunnelData[];
-                const closestPoint = data[0]?.items.find((item) => {
-                    return (
-                        pointerX >= item.x &&
-                        pointerX <= item.x + item.width &&
-                        pointerY >= item.y &&
-                        pointerY <= item.y + item.height
-                    );
-                });
-                if (closestPoint) {
-                    result.push({
-                        data: closestPoint.data,
-                        series: closestPoint.series,
-                        closest: true,
-                    });
-                }
-
-                break;
-            }
-            case 'x-range': {
-                const data = list as unknown as PreparedXRangeData[];
-                const pointsInXRange = data.filter(
-                    (d) =>
-                        pointerX >= d.x &&
-                        pointerX <= d.x + d.width &&
-                        pointerY >= d.y &&
-                        pointerY <= d.y + d.height,
-                );
-
-                if (pointsInXRange.length === 0) {
-                    break;
-                }
-
-                const closestByX =
-                    pointsInXRange.length === 1
-                        ? pointsInXRange[0]
-                        : sort(pointsInXRange, (d) => Math.abs(d.x + d.width / 2 - pointerX))[0];
-
-                result.push(
-                    ...pointsInXRange.map((d) => ({
-                        data: d.data,
-                        series: d.series as unknown as XRangeSeries,
-                        closest: d === closestByX,
-                    })),
-                );
-
-                break;
-            }
+    for (const [seriesType, list] of Object.entries(groups)) {
+        const fn = tooltipFnByType[seriesType];
+        if (!fn) {
+            continue;
         }
-    });
 
-    if (closestPointsByXValue.length) {
+        const {chunks, xLookupPoints: seriesXLookupPoints} = fn({
+            data: list,
+            position,
+            boundsWidth,
+            boundsHeight,
+        });
+
+        result.push(...chunks);
+        if (seriesXLookupPoints) {
+            xLookupPoints.push(...seriesXLookupPoints);
+        }
+    }
+
+    if (xLookupPoints.length) {
         result.push(
-            ...(getClosestPointsByXValue(
-                pointerX,
-                pointerY,
-                closestPointsByXValue,
-            ) as TooltipDataChunk[]),
+            ...(getClosestPointsByXValue(pointerX, pointerY, xLookupPoints) as TooltipDataChunk[]),
         );
     }
 
     return result;
-}
-
-function isInsidePath(args: {
-    path: string;
-    point: [number, number];
-    width: number;
-    height: number;
-    strokeWidth: number;
-}) {
-    const {path, point, width, height, strokeWidth} = args;
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-
-    const ctx = canvas.getContext('2d');
-    if (ctx) {
-        ctx.lineWidth = strokeWidth;
-        const path2D = new Path2D(path);
-        ctx.stroke(path2D);
-        return ctx.isPointInPath(path2D, ...point) || ctx.isPointInStroke(path2D, ...point);
-    }
-
-    return null;
-}
-
-function getRadius(args: {pointer: [number, number]; center: [number, number]}) {
-    const {pointer, center} = args;
-    const x = pointer[0] - center[0];
-    const y = pointer[1] - center[1];
-    const polarRadius = Math.sqrt(x * x + y * y);
-
-    return polarRadius;
 }

--- a/src/core/utils/tooltip-helpers.ts
+++ b/src/core/utils/tooltip-helpers.ts
@@ -1,0 +1,132 @@
+import {bisector, sort} from 'd3-array';
+import get from 'lodash/get';
+import groupBy from 'lodash/groupBy';
+
+import type {ChartSeries, ChartSeriesData, MeaningfulAny, TooltipDataChunk} from '../../types';
+
+export type ShapePoint = {
+    x: number;
+    y0: number;
+    y1: number;
+    data: ChartSeriesData;
+    series: ChartSeries;
+    subTotal?: number;
+    sourceX?: number;
+};
+
+export interface GetTooltipDataArgs<TShapeData = unknown> {
+    data: TShapeData[];
+    position: [number, number];
+    boundsWidth: number;
+    boundsHeight: number;
+}
+
+export interface GetTooltipDataResult {
+    chunks: TooltipDataChunk[];
+    xLookupPoints?: ShapePoint[];
+}
+
+export type GetTooltipDataFn = (args: GetTooltipDataArgs<MeaningfulAny>) => GetTooltipDataResult;
+
+export function getClosestYIndex(items: ShapePoint[], y: number) {
+    let closestYIndex = -1;
+    if (y < items[0]?.y0) {
+        closestYIndex = 0;
+    } else if (y > items[items.length - 1]?.y1) {
+        closestYIndex = items.length - 1;
+    } else {
+        closestYIndex = items.findIndex((p) => y > p.y0 && y < p.y1);
+        if (closestYIndex === -1) {
+            const sortedY = sort(
+                items.map((p, index) => ({index, y: p.y1 + (p.y0 - p.y1) / 2})),
+                (p) => p.y,
+            );
+            const sortedYIndex = bisector<{y: number}, number>((p) => p.y).center(sortedY, y);
+            closestYIndex = sortedY[sortedYIndex]?.index ?? -1;
+        }
+    }
+
+    return closestYIndex;
+}
+
+export function getClosestPointsByXValue(x: number, y: number, points: ShapePoint[]) {
+    const sorted = sort(points, (p) => p.x);
+    const closestXIndex = bisector<ShapePoint, number>((p) => p.x).center(sorted, x);
+
+    if (sorted.length === 0 || closestXIndex === -1) {
+        return [];
+    }
+
+    const closestX = Math.round(sorted[closestXIndex].x);
+    const filtered = points.filter((p) => Math.round(p.x) === closestX);
+
+    const groupedBySeries = Object.values(groupBy(filtered, (p) => get(p.series, 'id'))).map(
+        (items) => {
+            const sortedByY = sort(items, (p) => p.y0);
+            const index = getClosestYIndex(sortedByY, y);
+            return sortedByY[index === -1 ? 0 : index];
+        },
+    );
+
+    const closestPoints = sort(groupedBySeries, (p) => p.y0);
+
+    const pointsWithSourceX = closestPoints.filter((p) => p.sourceX !== undefined);
+    const uniqueSourceX = new Set(pointsWithSourceX.map((p) => p.sourceX));
+
+    if (pointsWithSourceX.length > 1 && uniqueSourceX.size > 1) {
+        const sortedBySourceX = sort(pointsWithSourceX, (p) => p.sourceX ?? 0);
+        const closestSourceXIdx = bisector<ShapePoint, number>((p) => p.sourceX ?? 0).center(
+            sortedBySourceX,
+            x,
+        );
+        const closestSourceX = sortedBySourceX[closestSourceXIdx]?.sourceX;
+
+        const candidates = closestPoints.filter(
+            (p) => p.sourceX === undefined || p.sourceX === closestSourceX,
+        );
+        const sortedCandidates = sort(candidates, (p) => p.y0);
+        const winnerIdx = getClosestYIndex(sortedCandidates, y);
+        const winner = sortedCandidates[winnerIdx === -1 ? 0 : winnerIdx];
+
+        return closestPoints.map((p) => ({
+            ...p,
+            closest: p === winner,
+        }));
+    }
+
+    const closestYIndex = getClosestYIndex(closestPoints, y);
+    return closestPoints.map((p, i) => ({
+        ...p,
+        closest: i === closestYIndex,
+    }));
+}
+
+export function isInsidePath(args: {
+    path: string;
+    point: [number, number];
+    width: number;
+    height: number;
+    strokeWidth: number;
+}) {
+    const {path, point, width, height, strokeWidth} = args;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+        ctx.lineWidth = strokeWidth;
+        const path2D = new Path2D(path);
+        ctx.stroke(path2D);
+        return ctx.isPointInPath(path2D, ...point) || ctx.isPointInStroke(path2D, ...point);
+    }
+
+    return null;
+}
+
+export function getRadius(args: {pointer: [number, number]; center: [number, number]}) {
+    const {pointer, center} = args;
+    const x = pointer[0] - center[0];
+    const y = pointer[1] - center[1];
+    return Math.sqrt(x * x + y * y);
+}


### PR DESCRIPTION
Replaces the 494-line switch-statement in `get-closest-data.ts` with a thin orchestrator. Each series type now owns its `getTooltipData` function in `shapes/[type]/get-tooltip-data.ts`; shared algorithms live in `utils/tooltip-helpers.ts`.