### PR TITLE
fix: use ResizeObserver instead of window.resize for chart dimensions

### DIFF
--- a/src/__stories__/Other/ResizableContainer.stories.tsx
+++ b/src/__stories__/Other/ResizableContainer.stories.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+
+import type {Meta, StoryObj} from '@storybook/react';
+
+import {Chart} from '../../components';
+import type {ChartData} from '../../types';
+
+const chartData: ChartData = {
+    series: {
+        data: [
+            {
+                type: 'line',
+                name: 'Series A',
+                data: [
+                    {x: 0, y: 10},
+                    {x: 1, y: 25},
+                    {x: 2, y: 18},
+                    {x: 3, y: 32},
+                    {x: 4, y: 27},
+                    {x: 5, y: 40},
+                    {x: 6, y: 35},
+                ],
+            },
+        ],
+    },
+    xAxis: {title: {text: 'X'}},
+    yAxis: [{title: {text: 'Y'}}],
+};
+
+// ─── Resizable Container ───
+
+function ResizablePanel({
+    children,
+    initialWidth,
+}: {
+    children: React.ReactNode;
+    initialWidth: number;
+}) {
+    const [width, setWidth] = React.useState(initialWidth);
+    const dragging = React.useRef(false);
+    const startX = React.useRef(0);
+    const startWidth = React.useRef(0);
+
+    const onPointerDown = React.useCallback(
+        (e: React.PointerEvent) => {
+            dragging.current = true;
+            startX.current = e.clientX;
+            startWidth.current = width;
+            (e.target as HTMLElement).setPointerCapture(e.pointerId);
+        },
+        [width],
+    );
+
+    const onPointerMove = React.useCallback((e: React.PointerEvent) => {
+        if (!dragging.current) return;
+        const delta = e.clientX - startX.current;
+        setWidth(Math.min(1200, Math.max(200, startWidth.current + delta)));
+    }, []);
+
+    const onPointerUp = React.useCallback(() => {
+        dragging.current = false;
+    }, []);
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column', gap: 4}}>
+            <div style={{fontSize: 12, color: '#888', fontFamily: 'monospace'}}>
+                Resizable panel — drag right edge
+            </div>
+            <div
+                style={{
+                    display: 'flex',
+                    width,
+                    border: '2px solid #e0e0e0',
+                    borderRadius: 8,
+                    overflow: 'hidden',
+                }}
+            >
+                <div style={{flex: 1, height: 280, minWidth: 0}}>{children}</div>
+                <div
+                    onPointerDown={onPointerDown}
+                    onPointerMove={onPointerMove}
+                    onPointerUp={onPointerUp}
+                    style={{
+                        width: 14,
+                        cursor: 'col-resize',
+                        background: '#e8e8e8',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                        userSelect: 'none',
+                        touchAction: 'none',
+                        fontSize: 10,
+                        color: '#999',
+                    }}
+                >
+                    ⋮
+                </div>
+            </div>
+            <div style={{fontSize: 11, color: '#aaa', fontFamily: 'monospace'}}>
+                container width: {Math.round(width)}px
+            </div>
+        </div>
+    );
+}
+
+// ─── Demo ───
+
+function ResizableContainerDemo() {
+    const [resizeCount, setResizeCount] = React.useState(0);
+    const [lastWidth, setLastWidth] = React.useState<number | undefined>();
+
+    const handleResize = React.useCallback<
+        NonNullable<React.ComponentProps<typeof Chart>['onResize']>
+    >(({dimensions}) => {
+        if (dimensions) {
+            setResizeCount((c) => c + 1);
+            setLastWidth(dimensions.width);
+        }
+    }, []);
+
+    return (
+        <div style={{padding: 16, fontFamily: 'sans-serif'}}>
+            <h3 style={{margin: '0 0 8px'}}>Resizable Container</h3>
+            <p style={{margin: '0 0 16px', color: '#666', fontSize: 14, maxWidth: 700}}>
+                The chart automatically adapts when the container is resized via drag — no{' '}
+                <code>reflow()</code> call needed. Powered by <code>ResizeObserver</code> on the
+                parent element.
+            </p>
+
+            <ResizablePanel initialWidth={600}>
+                <Chart data={chartData} onResize={handleResize} />
+            </ResizablePanel>
+
+            <div
+                style={{
+                    marginTop: 12,
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                    color: '#999',
+                    display: 'flex',
+                    gap: 24,
+                }}
+            >
+                <span>onResize calls: {resizeCount}</span>
+                <span>chart width: {lastWidth ?? '—'}px</span>
+            </div>
+        </div>
+    );
+}
+
+// ─── Storybook ───
+
+const meta: Meta = {
+    title: 'Other/Resizable Container',
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Demo: Story = {
+    name: 'Resizable Container',
+    render: () => <ResizableContainerDemo />,
+};

--- a/src/components/__tests__/chart-reflow.test.tsx
+++ b/src/components/__tests__/chart-reflow.test.tsx
@@ -26,6 +26,8 @@ const data: ChartData = {
     },
 };
 
+declare const __triggerResizeObserver: (target: Element) => void;
+
 describe('Chart/reflow', () => {
     afterEach(() => {
         document.body.innerHTML = '';
@@ -98,5 +100,58 @@ describe('Chart/reflow', () => {
             ref.current?.reflow({immediate: true});
         });
         expect(onResize).toHaveBeenCalledTimes(1);
+    });
+
+    test('container resize (without window.resize) triggers onResize via ResizeObserver', async () => {
+        jest.useFakeTimers();
+        const onResize = jest.fn();
+
+        const {container} = renderChart(<Chart data={data} onResize={onResize} />);
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        onResize.mockClear();
+
+        // simulate container width change (e.g. drawer drag)
+        Object.defineProperty(container, 'clientWidth', {value: 600, configurable: true});
+
+        act(() => {
+            __triggerResizeObserver(container);
+        });
+
+        // not called yet — within debounce window
+        expect(onResize).not.toHaveBeenCalled();
+
+        await act(async () => {
+            jest.advanceTimersByTime(200);
+        });
+
+        expect(onResize).toHaveBeenCalledTimes(1);
+        expect(onResize).toHaveBeenCalledWith({
+            dimensions: {width: 600, height: 400},
+        });
+    });
+
+    test('ResizeObserver does not trigger onResize when dimensions stay the same', async () => {
+        jest.useFakeTimers();
+        const onResize = jest.fn();
+
+        const {container} = renderChart(<Chart data={data} onResize={onResize} />);
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        onResize.mockClear();
+
+        act(() => {
+            __triggerResizeObserver(container);
+        });
+
+        await act(async () => {
+            jest.advanceTimersByTime(200);
+        });
+
+        expect(onResize).not.toHaveBeenCalled();
     });
 });

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import {select} from 'd3-selection';
 import type {DebouncedFunc} from 'lodash';
 import debounce from 'lodash/debounce';
 
 import {i18nFactory} from '~core/i18n';
-import {getUniqId} from '~core/utils';
 import {validateData} from '~core/validation';
 
 import type {ChartData} from '../types';
@@ -27,6 +25,10 @@ export interface ChartDimentions {
     width: number;
 }
 
+interface HandleResizeOptions {
+    force?: boolean;
+}
+
 export type ChartOnResize = (args: {dimensions?: ChartDimentions}) => void;
 
 export interface ChartProps {
@@ -40,7 +42,9 @@ export const Chart = React.forwardRef<ChartRef, ChartProps>(function Chart(props
     const {data, lang, onResize, onReady} = props;
     const validatedData = React.useRef<ChartData>();
     const ref = React.useRef<HTMLDivElement>(null);
-    const debounced = React.useRef<DebouncedFunc<() => void> | undefined>();
+    const debounced = React.useRef<
+        DebouncedFunc<(options?: HandleResizeOptions) => void> | undefined
+    >();
     const [dimensions, setDimensions] = React.useState<ChartDimentions>();
 
     if (validatedData.current !== data) {
@@ -48,11 +52,26 @@ export const Chart = React.forwardRef<ChartRef, ChartProps>(function Chart(props
         validatedData.current = data;
     }
 
-    const handleResize = React.useCallback(() => {
+    const handleResize = React.useCallback((options?: HandleResizeOptions) => {
         const parentElement = ref.current?.parentElement;
 
         if (parentElement) {
-            setDimensions({width: parentElement.clientWidth, height: parentElement.clientHeight});
+            const nextDimensions = {
+                width: parentElement.clientWidth,
+                height: parentElement.clientHeight,
+            };
+
+            setDimensions((currentDimensions) => {
+                if (
+                    !options?.force &&
+                    currentDimensions?.width === nextDimensions.width &&
+                    currentDimensions.height === nextDimensions.height
+                ) {
+                    return currentDimensions;
+                }
+
+                return nextDimensions;
+            });
         }
     }, []);
 
@@ -67,9 +86,9 @@ export const Chart = React.forwardRef<ChartRef, ChartProps>(function Chart(props
         () => ({
             reflow(options?: ChartReflowOptions) {
                 if (options?.immediate) {
-                    handleResize();
+                    handleResize({force: true});
                 } else {
-                    debuncedHandleResize();
+                    debuncedHandleResize({force: true});
                 }
             },
         }),
@@ -82,22 +101,20 @@ export const Chart = React.forwardRef<ChartRef, ChartProps>(function Chart(props
     }, [handleResize]);
 
     React.useEffect(() => {
-        const selection = select(window);
-        // https://github.com/d3/d3-selection/blob/main/README.md#handling-events
-        const eventName = `resize.${getUniqId()}`;
-        selection.on(eventName, debuncedHandleResize);
+        const parentElement = ref.current?.parentElement;
 
-        window.addEventListener('transitionend', handleResize, {capture: true});
-        window.addEventListener('animationend', handleResize, {capture: true});
+        if (!parentElement) {
+            return undefined;
+        }
+
+        const observer = new ResizeObserver(() => debuncedHandleResize());
+        observer.observe(parentElement);
 
         return () => {
-            // https://d3js.org/d3-selection/events#selection_on
-            selection.on(eventName, null);
-
-            window.removeEventListener('transitionend', handleResize, {capture: true});
-            window.removeEventListener('animationend', handleResize, {capture: true});
+            observer.disconnect();
+            debuncedHandleResize.cancel();
         };
-    }, [debuncedHandleResize, handleResize]);
+    }, [debuncedHandleResize]);
 
     React.useEffect(() => {
         if (typeof onResize === 'function') {

--- a/src/setup-jsdom.ts
+++ b/src/setup-jsdom.ts
@@ -12,10 +12,42 @@ if (typeof document !== 'undefined') {
 }
 
 if (typeof ResizeObserver === 'undefined') {
+    const resizeObserverCallbacks = new Map<Element, Set<ResizeObserverCallback>>();
+
     global.ResizeObserver = class ResizeObserver {
-        observe() {}
-        unobserve() {}
-        disconnect() {}
+        private callback: ResizeObserverCallback;
+
+        constructor(callback: ResizeObserverCallback) {
+            this.callback = callback;
+        }
+
+        observe(target: Element) {
+            if (!resizeObserverCallbacks.has(target)) {
+                resizeObserverCallbacks.set(target, new Set());
+            }
+            resizeObserverCallbacks.get(target)!.add(this.callback);
+        }
+
+        unobserve(target: Element) {
+            resizeObserverCallbacks.get(target)?.delete(this.callback);
+        }
+
+        disconnect() {
+            resizeObserverCallbacks.forEach((callbacks) => {
+                callbacks.delete(this.callback);
+            });
+        }
+    };
+
+    /**
+     * Test helper: simulate a ResizeObserver notification for the given element.
+     */
+    (global as any).__triggerResizeObserver = (target: Element) => {
+        const callbacks = resizeObserverCallbacks.get(target);
+        if (callbacks) {
+            const entry = [{target, contentRect: target.getBoundingClientRect()}] as any;
+            callbacks.forEach((cb) => cb(entry, {} as any));
+        }
     };
 }
 


### PR DESCRIPTION
## Problem

The `Chart` component determines its render dimensions by reading `parentElement.clientWidth` and `parentElement.clientHeight`. Re-measurement is triggered by `window.resize`, `transitionend`, and `animationend` global events.

When the chart is placed inside a **resizable container** whose size changes independently of the browser window (drawer, split-pane, CSS class toggle), the chart does **not** adapt — because `window.resize` never fires.

### Real-world case

In DataLens, charts rendered inside a resizable `<Drawer>` (AI chat panel) stay at their initial width when the user drags the drawer edge. A workaround (`ResizeObserver` + `reflow()`) is currently applied at every integration site.

## Solution

Replace `window.resize` + `transitionend` + `animationend` global listeners with a `ResizeObserver` on `parentElement`.

### What changes

| Aspect | Before | After |
|--------|--------|-------|
| Trigger | `window.resize`, `transitionend`, `animationend` | `ResizeObserver` on `parentElement` |
| Window resize | ✅ | ✅ |
| Container resize (drawer, split-pane) | ❌ | ✅ |
| CSS transition/animation resize | ✅ (fires on ALL elements) | ✅ (scoped to parent) |
| Performance | Global event listeners | Scoped to one element |

### Changes

- **`src/components/index.tsx`** — `ResizeObserver` on `parentElement` instead of global listeners; removed `d3-selection` and `getUniqId` imports from this file
- **`src/setup-jsdom.ts`** — functional `ResizeObserver` mock with `__triggerResizeObserver()` test helper
- **`src/components/__tests__/chart-reflow.test.tsx`** — new test: container resize via `ResizeObserver` triggers `onResize`
- **`src/__stories__/Other/ResizableContainer.stories.tsx`** — interactive demo with a draggable resizable panel

### Breaking changes

None — same external API, same `reflow()` method.

### Browser support

[ResizeObserver](https://caniuse.com/resizeobserver) is supported in all modern browsers (Chrome 64+, Firefox 69+, Safari 13.1+, Edge 79+).
