### PR TITLE
fix: correct sideEffects paths to prevent tree-shaking of plugin registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "sideEffects": [
     "*.css",
     "*.scss",
-    "./src/plugins/index.ts"
+    "./dist/esm/plugins/index.js",
+    "./dist/cjs/plugins/index.js"
   ],
   "files": [
     "dist",


### PR DESCRIPTION
## Problem                                                                                                                        
                                                                                                                                    
  Plugins were not registered when consuming the library externally, causing:
                                                                                                                                    
  > Unknown series type: "bar-x"
                                                                                                                                    
  The `sideEffects` field pointed to `./src/plugins/index.ts` — a source path that doesn't exist in the published package (only `dist/` is shipped). Bundlers (webpack, vite) had no signal to preserve the `import './plugins'` side effect in `dist/esm/index.js` and could tree-shake it away, leaving the plugin registry empty.                           
                                                                                                                                    
  ## Fix                                                    
        
  Replace the source path with the actual dist paths that bundlers will see when processing the package.