### PR TITLE
fix: add entry points to sideEffects to prevent tree-shaking of plugin registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,8 @@
   "sideEffects": [
     "*.css",
     "*.scss",
-    "./dist/esm/index.js",
-    "./dist/cjs/index.js",
-    "./dist/esm/plugins/index.js",
-    "./dist/cjs/plugins/index.js"
+    "**/plugins/index.*",
+    "./dist/*/index.js"
   ],
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "sideEffects": [
     "*.css",
     "*.scss",
-    "./src/plugins/index.ts",
     "./dist/esm/index.js",
     "./dist/cjs/index.js",
     "./dist/esm/plugins/index.js",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "sideEffects": [
     "*.css",
     "*.scss",
+    "./dist/esm/index.js",
+    "./dist/cjs/index.js",
     "./dist/esm/plugins/index.js",
     "./dist/cjs/plugins/index.js"
   ],


### PR DESCRIPTION
Rollup in consumers' production builds was dropping import './plugins' from dist/esm/index.js because the main entry point was not marked as a side-effect module. Adding index.js (esm and cjs) to sideEffects ensures plugin registration is not eliminated during tree-shaking.