### PR TITLE
fix: move plugin registration from entry point to Chart component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,8 +5,6 @@ import {Controls, Description, Primary, Subtitle, Title} from '@storybook/addon-
 import type {Preview} from '@storybook/react-vite';
 import {MINIMAL_VIEWPORTS} from 'storybook/viewport';
 
-import '../src/plugins';
-
 import {WithContext} from './decorators/withContext';
 import {WithLang} from './decorators/withLang';
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "sideEffects": [
     "*.css",
     "*.scss",
-    "**/plugins/index.*",
-    "./dist/*/index.js"
+    "**/plugins/index.*"
   ],
   "files": [
     "dist",

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -6,6 +6,7 @@ import debounce from 'lodash/debounce';
 import {i18nFactory} from '~core/i18n';
 import {validateData} from '~core/validation';
 
+import '../plugins';
 import type {ChartData} from '../types';
 
 import {ChartInner} from './ChartInner';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import './plugins';
-
 export {CustomShapeRenderer} from './utils';
 export {getFormattedValue} from '~core/utils';
 export {getDefaultTooltipHeaderFormat} from '~core/utils/tooltip';

--- a/src/setup-jsdom.ts
+++ b/src/setup-jsdom.ts
@@ -1,5 +1,3 @@
-import './plugins';
-
 // Global mocks for jsdom environment.
 // Guarded by typeof checks so this file is safe to run in the `node` environment too.
 


### PR DESCRIPTION
import './plugins' in the package entry point (`src/index.ts`) registered all built-in series types as a side effect of simply importing the package. To prevent tree-shaking, `./dist/*/index.js` was added to sideEffects — which forced bundlers to include the entire charts bundle in the initial chunk even when `<Chart /> `was lazy-loaded. Any package re-exporting from `@gravity-ui/charts` (e.g. `@gravity-ui/chartkit`) was effectively opting all its users into a non-lazy bundle.

  Plugin registration belongs to the component that renders charts, not the package entry point. Moved import '../plugins' to             
  `src/components/index.tsx` — it still runs automatically whenever `<Chart />` is used, so there is no behavioral change. Removed `./dist/*/index.js` from sideEffects: the entry point is now side-effect-free and bundlers can tree-shake it freely.