### PR TITLE
fix(area): hide synthetic stack points from tooltip and data labels

### DIFF
--- a/src/__stories__/Area/Area.stories.tsx
+++ b/src/__stories__/Area/Area.stories.tsx
@@ -8,6 +8,7 @@ import {
     areaHtmlLabelsData,
     areaPlaygroundData,
     areaSplitData,
+    areaStakingHeterogeneousData,
     areaStakingNormalData,
     areaStakingPercentData,
 } from '../__data__';
@@ -41,6 +42,13 @@ export const AreaStakingPercent = {
     name: 'Staking percent',
     args: {
         data: areaStakingPercentData,
+    },
+} satisfies Story;
+
+export const AreaStakingHeterogeneous = {
+    name: 'Staking heterogeneous data',
+    args: {
+        data: areaStakingHeterogeneousData,
     },
 } satisfies Story;
 

--- a/src/__stories__/__data__/area/index.ts
+++ b/src/__stories__/__data__/area/index.ts
@@ -3,6 +3,7 @@ export * from './basic';
 export * from './html-labels';
 export * from './negative-values';
 export * from './null-modes';
+export * from './staking-heterogeneous';
 export * from './staking-normal';
 export * from './staking-percent';
 export * from './playground';

--- a/src/__stories__/__data__/area/staking-heterogeneous.ts
+++ b/src/__stories__/__data__/area/staking-heterogeneous.ts
@@ -1,0 +1,49 @@
+import type {AreaSeries, ChartData} from '../../../types';
+
+const categories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+
+function prepareData(): ChartData {
+    const seriesData: AreaSeries[] = [
+        {
+            type: 'area',
+            stacking: 'normal',
+            name: 'Series A (Jan, Feb, Mar)',
+            data: [
+                {x: 'Jan', y: 10},
+                {x: 'Feb', y: 20},
+                {x: 'Mar', y: 15},
+            ],
+        },
+        {
+            type: 'area',
+            stacking: 'normal',
+            name: 'Series B (Mar, Apr, May)',
+            data: [
+                {x: 'Mar', y: 25},
+                {x: 'Apr', y: 30},
+                {x: 'May', y: 18},
+            ],
+        },
+        {
+            type: 'area',
+            stacking: 'normal',
+            name: 'Series C (May, Jun)',
+            data: [
+                {x: 'May', y: 12},
+                {x: 'Jun', y: 22},
+            ],
+        },
+    ];
+
+    return {
+        series: {
+            data: seriesData,
+        },
+        xAxis: {
+            type: 'category',
+            categories,
+        },
+    };
+}
+
+export const areaStakingHeterogeneousData = prepareData();

--- a/src/__tests__/area-series.visual.test.tsx
+++ b/src/__tests__/area-series.visual.test.tsx
@@ -1021,4 +1021,72 @@ test.describe('Area series', () => {
             expect(texts.slice().sort()).toEqual(['12', '7']);
         });
     });
+
+    test.describe('Stacked heterogeneous data', () => {
+        test('synthetic points are hidden from the tooltip', async ({page, mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series 1',
+                            stacking: 'normal',
+                            data: [
+                                {x: 1, y: 7},
+                                {x: 2, y: 30},
+                            ],
+                        },
+                        {
+                            type: 'area',
+                            name: 'Series 2',
+                            stacking: 'normal',
+                            data: [{x: 1, y: 5}],
+                        },
+                    ],
+                },
+            };
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const area = component.locator('.gcharts-area__series').first();
+            const areaBox = await getLocatorBoundingBox(area);
+            await page.mouse.move(
+                Math.round(areaBox.x + areaBox.width),
+                Math.round(areaBox.y + areaBox.height / 2),
+            );
+            const rows = page.locator('.gcharts-tooltip__content-row');
+            await expect(rows).toHaveCount(1);
+            await expect(rows.first()).toContainText('Series 1');
+        });
+
+        test('synthetic points do not produce data labels', async ({mount}) => {
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            type: 'area',
+                            name: 'Series 1',
+                            stacking: 'normal',
+                            data: [
+                                {x: 1, y: 7},
+                                {x: 2, y: 30},
+                                {x: 3, y: 12},
+                            ],
+                            dataLabels: {enabled: true},
+                        },
+                        {
+                            type: 'area',
+                            name: 'Series 2',
+                            stacking: 'normal',
+                            data: [{x: 2, y: 5}],
+                            dataLabels: {enabled: true},
+                        },
+                    ],
+                },
+            };
+            const component = await mount(<ChartTestStory data={chartData} />);
+            const labels = component.locator('.gcharts-area__label');
+            await expect(labels).toHaveCount(4);
+            const texts = await labels.allTextContents();
+            expect(texts.slice().sort()).toEqual(['12', '30', '5', '7']);
+        });
+    });
 });

--- a/src/core/shapes/area/prepare-data.ts
+++ b/src/core/shapes/area/prepare-data.ts
@@ -20,6 +20,13 @@ import {
 
 import type {PointData, PreparedAreaData} from './types';
 
+const SYNTHETIC_POINT: AreaSeriesData = {
+    x: 0,
+    y: 0,
+    tooltip: {enabled: false},
+    dataLabels: {enabled: false},
+};
+
 function getXValues(series: PreparedAreaSeries[], xAxis: PreparedXAxis, xScale: ChartScale) {
     const categories = xAxis.categories || [];
     const xValues = series.reduce<Map<string, number>>((acc, s) => {
@@ -192,12 +199,7 @@ export const prepareAreaData = async (args: {
                 for (let xIdx = 0; xIdx < xValues.length; xIdx++) {
                     const [x, xValue] = xValues[xIdx];
                     const rawData = seriesData.get(x);
-                    const d =
-                        rawData ??
-                        ({
-                            x,
-                            y: 0,
-                        } as AreaSeriesData);
+                    const d = rawData ?? SYNTHETIC_POINT;
                     let yDataValue = d.y ?? null;
                     const pointAnnotation =
                         d.annotation && !isRangeSlider


### PR DESCRIPTION
## Summary
- In stacked area charts with heterogeneous data, the engine inserts synthetic `{x, y: 0}` points to keep polygon geometry continuous across gaps in series data.
- These points are needed for rendering but were also surfaced in tooltips and data labels as fake zeros.
- Fix: tag the synthetic point with the existing per-point overrides (`tooltip.enabled = false`, `dataLabels.enabled = false`) so it stays in the render path but is filtered out by `isPointTooltipEnabled` and `isPointDataLabelEnabled`.
- Hoisted to a module-level constant since the shape is identical across all uses.