### PR TITLE
fix: fix labels hidden when xAxis order is reversed

### DIFF
--- a/src/__tests__/line-series.visual.test.tsx
+++ b/src/__tests__/line-series.visual.test.tsx
@@ -268,6 +268,39 @@ test.describe('Line series', () => {
             await expect(component.locator('svg')).toHaveScreenshot();
         });
 
+        test('DataLabels visible with reversed datetime xAxis', async ({mount}) => {
+            const DAY = 24 * 60 * 60 * 1000;
+            const startMs = Date.UTC(2024, 0, 1);
+            const chartData: ChartData = {
+                series: {
+                    data: [
+                        {
+                            name: 'Series',
+                            type: 'line',
+                            data: [
+                                {x: startMs, y: 10, label: 'A'},
+                                {x: startMs + DAY, y: 20, label: 'B'},
+                                {x: startMs + 2 * DAY, y: 15, label: 'C'},
+                            ],
+                            dataLabels: {enabled: true},
+                        },
+                    ],
+                },
+                xAxis: {type: 'datetime', order: 'reverse'},
+            };
+
+            const component = await mount(<ChartTestStory data={chartData} />);
+
+            const labels = component.locator('.gcharts-line__label');
+            await expect(labels).toHaveCount(3);
+
+            const count = await labels.count();
+            for (let i = 0; i < count; i++) {
+                const x = Number(await labels.nth(i).getAttribute('x'));
+                expect(x).toBeGreaterThanOrEqual(0);
+            }
+        });
+
         test('Overlapping html labels should not be displayed (by default)', async ({mount}) => {
             const longLabel = 'On seashore far a green oak towers ...';
             const chartData: ChartData = {

--- a/src/core/shapes/area/prepare-data.ts
+++ b/src/core/shapes/area/prepare-data.ts
@@ -80,8 +80,7 @@ export const prepareAreaData = async (args: {
         isOutsideBounds,
         isRangeSlider,
     } = args;
-    const [_xMin, xRangeMax] = xScale.range();
-    const xMax = xRangeMax;
+    const xMax = Math.max(...xScale.range());
 
     const result: PreparedAreaData[] = [];
     const dataByPlots = Array.from(

--- a/src/core/shapes/bar-x/prepare-data.ts
+++ b/src/core/shapes/bar-x/prepare-data.ts
@@ -362,8 +362,7 @@ export const prepareBarXData = async (args: {
         }
     }
 
-    const [_xMin, xRangeMax] = xScale.range();
-    const xMax = xRangeMax;
+    const xMax = Math.max(...xScale.range());
 
     for (let i = 0; i < result.length; i++) {
         const barData = result[i];

--- a/src/core/shapes/line/prepare-data.ts
+++ b/src/core/shapes/line/prepare-data.ts
@@ -35,8 +35,7 @@ export const prepareLineData = async (args: {
         isRangeSlider,
         otherLayers,
     } = args;
-    const [_xMin, xRangeMax] = xScale.range();
-    const xMax = xRangeMax;
+    const xMax = Math.max(...xScale.range());
 
     const acc: PreparedLineData[] = [];
     for (let i = 0; i < series.length; i++) {

--- a/src/core/shapes/scatter/prepare-data.ts
+++ b/src/core/shapes/scatter/prepare-data.ts
@@ -65,8 +65,7 @@ export async function prepareScatterData(args: {
 }): Promise<PreparedScatterShapeData> {
     const {series, xAxis, xScale, yAxis, yScale, split, isOutsideBounds, isRangeSlider} = args;
 
-    const [_xMin, xRangeMax] = xScale.range();
-    const xMax = xRangeMax;
+    const xMax = Math.max(...xScale.range());
 
     const markers: PreparedScatterData[] = series.reduce<PreparedScatterData[]>((acc, s) => {
         const yAxisIndex = get(s, 'yAxis', 0);


### PR DESCRIPTION
When xAxis.order: 'reverse' is set on a datetime axis, the x-scale range becomes [boundsWidth, 0]. Taking the second element as xMax yielded 0, causing all label x-positions to be calculated as negative (off-screen).