### PR TITLE
docs: add missing series API pages and fix JSDoc errors

### DIFF
--- a/docs/src/Series/Funnel/index.ts
+++ b/docs/src/Series/Funnel/index.ts
@@ -1,0 +1,1 @@
+export * from '../../../../src/core/types/chart/funnel';

--- a/docs/src/Series/Heatmap/index.ts
+++ b/docs/src/Series/Heatmap/index.ts
@@ -1,0 +1,1 @@
+export * from '../../../../src/core/types/chart/heatmap';

--- a/docs/src/Series/Radar/index.ts
+++ b/docs/src/Series/Radar/index.ts
@@ -1,0 +1,1 @@
+export * from '../../../../src/core/types/chart/radar';

--- a/docs/src/Series/Sankey/index.ts
+++ b/docs/src/Series/Sankey/index.ts
@@ -1,0 +1,1 @@
+export * from '../../../../src/core/types/chart/sankey';

--- a/docs/src/Series/X-Range/index.ts
+++ b/docs/src/Series/X-Range/index.ts
@@ -1,0 +1,1 @@
+export * from '../../../../src/core/types/chart/x-range';

--- a/src/core/types/chart/axis.ts
+++ b/src/core/types/chart/axis.ts
@@ -437,7 +437,7 @@ export interface ChartYAxisTitle extends ChartAxisTitle {
      */
     rotation?: ChartAxisTitleRotation;
     /**
-     * Interval of the tick marks(absolute or relative to the chart area).
+     * Maximum width of the title (absolute or relative to the chart area).
      *
      * For a title with rotation = 0, the relative value is calculated based on the chart width, otherwise on the chart height.
      * The default value for the title with rotation: 0 is 20%, for the rest - not defined.

--- a/src/core/types/chart/base.ts
+++ b/src/core/types/chart/base.ts
@@ -31,7 +31,7 @@ export type CustomFormat = {
  * { type: 'number', precision: 2, format: 'percent' }
  * @example
  * // Compact thousands: 1 500 000 → "1.5M"
- * { type: 'number', unit: 'auto', precision: 1 }
+ * { type: 'number', units: { scale: { base: 1000, postfixes: ['', 'K', 'M', 'B', 'T'] }, delimiter: '' }, precision: 1 }
  * @example
  * // Date value (Unix ms) formatted as "17 October 2025"
  * { type: 'date', format: 'DD MMMM YYYY' }


### PR DESCRIPTION
Five series types (Funnel, Heatmap, Radar, Sankey, X-Range) were implemented but had no API documentation pages — only their tooltip chunks existed. Added the missing `docs/src/Series/*/index.ts` entry points so TypeDoc picks them up automatically on the next build.
                                                                                                                                  
Also fixed two JSDoc errors found during the audit: `ChartYAxisTitle.maxWidth` had a copy-pasted description from `ChartAxisTickMarks`, and the `ValueFormat` example used the deprecated `unit: 'auto'` option instead of the modern `units` syntax.