### PR TITLE
ci: skip docs preview for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -9,6 +9,10 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
+    # Dependabot PRs run in a restricted context without access to repository
+    # secrets, so the GitHub App token cannot be generated. Skip the docs
+    # preview for them — it is not needed for dependency bumps.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `PR Docs Preview` workflow fails on every Dependabot PR (e.g. #634) at the **Generate token** step:

```
Error: [@octokit/auth-app] appId option is required
```

and then cascades into the failure-comment step:

```
Error: Input required and not supplied: GITHUB_TOKEN
```

## Root cause

The job generates a GitHub App token from `secrets.GRAVITY_UI_APP_ID` / `secrets.GRAVITY_UI_APP_PRIVATE_KEY`. **Dependabot PRs run in a restricted context and have no access to regular Actions secrets** (Dependabot has its own separate secrets scope), so `app-id` resolves to an empty string and token generation fails.

This isn't a recent regression — the workflow (with the secret-based token step) was introduced in #532 on 2026-04-03, replacing the old build-only `docs-deploy-test.yml`. Between then and now there were simply **no Dependabot PRs** (last one 2026-03-07, next one 2026-06-10), so #634 is the first Dependabot PR to ever hit the new pipeline — and the first to fail.

## Fix

Skip the `build-and-deploy` job for `dependabot[bot]`. The docs preview/deploy isn't needed for dependency bumps, and the job is reported as **skipped** instead of failed.

```yaml
jobs:
  build-and-deploy:
    ...
    if: github.actor != 'dependabot[bot]'
```

Regular PRs are unaffected.