### PR TITLE
feat(funnel): add per-segment opacity support

### DIFF
--- a/src/core/series/types.ts
+++ b/src/core/series/types.ts
@@ -446,6 +446,7 @@ export type PreparedFunnelSeries = {
         preserveLineBreaks: boolean;
     };
     connectors: Required<FunnelSeries['connectors']>;
+    opacity: number | null;
 } & BasePreparedSeries;
 
 export type PreparedXRangeSeries = {

--- a/src/core/shapes/funnel/prepare-data.ts
+++ b/src/core/shapes/funnel/prepare-data.ts
@@ -190,6 +190,7 @@ export async function prepareFunnelData(args: Args): Promise<PreparedFunnelData>
             borderColor: '',
             borderWidth: 0,
             cursor: s.cursor,
+            opacity: s.opacity,
         };
         items.push(item);
 

--- a/src/core/shapes/funnel/renderer.ts
+++ b/src/core/shapes/funnel/renderer.ts
@@ -31,6 +31,7 @@ export function renderFunnel(
         .join('polygon')
         .attr('points', (d) => d.points.map((p) => p.join(',')).join(' '))
         .attr('fill', (d) => d.color)
+        .attr('opacity', (d) => d.opacity)
         .attr('stroke', (d) => d.borderColor)
         .attr('stroke-width', (d) => d.borderWidth);
 

--- a/src/core/shapes/funnel/types.ts
+++ b/src/core/shapes/funnel/types.ts
@@ -17,6 +17,7 @@ export type FunnelItemData = {
     borderColor: string;
     borderWidth: number;
     cursor: string | null;
+    opacity: number | null;
 };
 
 export type FunnelConnectorData = {

--- a/src/core/types/chart/funnel.ts
+++ b/src/core/types/chart/funnel.ts
@@ -17,6 +17,8 @@ export interface FunnelSeriesData<T = MeaningfulAny> extends BaseSeriesData<T> {
     name: string;
     /** Initial data label of the funnel segment. If not specified, the value is used. */
     label?: string;
+    /** Individual opacity for the funnel segment. */
+    opacity?: number;
     /** Individual series legend options. Has higher priority than legend options in series data */
     legend?: BaseSeriesLegend & {
         symbol?: RectLegendSymbolOptions;

--- a/src/plugins/funnel/prepare-funnel-series.ts
+++ b/src/plugins/funnel/prepare-funnel-series.ts
@@ -62,6 +62,7 @@ export function prepareFunnelSeries(args: PrepareFunnelSeriesArgs) {
                 itemText: dataItem.legend?.itemText ?? dataItem.name,
             },
             cursor: get(series, 'cursor', null),
+            opacity: dataItem.opacity ?? null,
             tooltip: series.tooltip,
             connectors: {
                 enabled: isConnectorsEnabled,


### PR DESCRIPTION
Added opacity field to funnel chart, allowing individual opacity control for each funnel segment