### PR TITLE
fix(scatter): tooltip on logarithmic axis with zero values

### DIFF
--- a/src/__tests__/scatter-series.visual.test.tsx
+++ b/src/__tests__/scatter-series.visual.test.tsx
@@ -14,6 +14,8 @@ import {
 } from '../__stories__/__data__';
 import type {ChartData} from '../types';
 
+import {getLocatorBoundingBox} from './utils';
+
 test.describe('Scatter series', () => {
     test('Basic', async ({mount}) => {
         const component = await mount(<ChartTestStory data={scatterBasicData} />);
@@ -165,6 +167,36 @@ test.describe('Scatter series', () => {
         set(dataWithMinMax, 'yAxis[0].max', 1);
         component.update(<ChartTestStory data={dataWithMinMax} />);
         await expect(component.locator('svg')).toHaveScreenshot();
+    });
+
+    test('Tooltip works correctly with y=0 on logarithmic axis', async ({mount, page}) => {
+        const data: ChartData = {
+            series: {
+                data: [
+                    {
+                        type: 'scatter',
+                        name: 'Series',
+                        data: [
+                            {x: 1, y: 10},
+                            {x: 2, y: 0},
+                            {x: 2, y: 100},
+                        ],
+                    },
+                ],
+            },
+            yAxis: [{type: 'logarithmic'}],
+        };
+
+        const component = await mount(<ChartTestStory data={data} />);
+        const box = await getLocatorBoundingBox(
+            component.locator('.gcharts-marker__wrapper').last(),
+        );
+
+        // Hover near x=2 (the y=0 point's position)
+        await page.mouse.move(Math.round(box.x), Math.round(box.y));
+
+        const tooltip = page.locator('.gcharts-tooltip');
+        await expect(tooltip.getByText('100', {exact: true})).toBeVisible();
     });
 
     test('x null values, nullMode=skip', async ({mount}) => {

--- a/src/core/shapes/scatter/prepare-data.ts
+++ b/src/core/shapes/scatter/prepare-data.ts
@@ -91,7 +91,7 @@ export async function prepareScatterData(args: {
             const x = getXValue({point: d, xAxis, xScale});
             const y = getYValue({point: d, yAxis: seriesYAxis, yScale: seriesYScale});
 
-            if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            if (x === null || y === null || !Number.isFinite(x) || !Number.isFinite(y)) {
                 return;
             }
 

--- a/src/core/shapes/scatter/prepare-data.ts
+++ b/src/core/shapes/scatter/prepare-data.ts
@@ -91,7 +91,7 @@ export async function prepareScatterData(args: {
             const x = getXValue({point: d, xAxis, xScale});
             const y = getYValue({point: d, yAxis: seriesYAxis, yScale: seriesYScale});
 
-            if (typeof x === 'undefined' || typeof y === 'undefined' || x === null || y === null) {
+            if (!Number.isFinite(x) || !Number.isFinite(y)) {
                 return;
             }
 


### PR DESCRIPTION
Points with y=0 are now correctly ignored on a logarithmic axis — the tooltip no longer breaks when the data contains zero values