### PR TITLE
docs: LLM-ready README + Validate README workflow

### DIFF
--- a/.github/workflows/validate-readme.yml
+++ b/.github/workflows/validate-readme.yml
@@ -1,0 +1,20 @@
+name: Validate README
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - README.md
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gravity-ui/readme-validator@v1
+        with:
+          type: package

--- a/README.md
+++ b/README.md
@@ -85,3 +85,14 @@ A declarative React charting library for Gravity UI apps — render line, area, 
 - **The data prop is `data`, shaped `{series: {data: [...]}}`.** Each entry in `series.data` is one series with its own `type` and `data` array — there is no top-level array of series.
 - **Nothing renders without a sized container.** `Chart` fills its parent, so give the wrapper an explicit height.
 - **Requires uikit setup.** Wrap in `ThemeProvider` and import `@gravity-ui/uikit/styles/styles.css`; `@gravity-ui/uikit` is a required peer dependency.
+
+### Useful docs
+
+- [Get started](./docs/diplodoc/pages/get-started.md)
+- [Theming](./docs/diplodoc/pages/guides/theming.md)
+- [Tooltip](./docs/diplodoc/pages/guides/tooltip.md)
+- [Legend](./docs/diplodoc/pages/guides/legend.md)
+- [HTML Content](./docs/diplodoc/pages/guides/html.md)
+- [Value Formatting](./docs/diplodoc/pages/guides/value-formatting.md)
+- [Data Labels](./docs/diplodoc/pages/guides/data-labels.md)
+- [Axis Types](./docs/diplodoc/pages/guides/axis-types.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,55 @@
 
 React charting library with 10+ chart types: area, bar, line, pie, scatter, treemap, and more.
 
+## Install
+
+```shell
+npm install @gravity-ui/uikit @gravity-ui/charts
+```
+
+`@gravity-ui/uikit` is a required peer dependency — it provides the theming and styles the charts rely on.
+
+## Usage
+
+Import the `@gravity-ui/uikit` styles once in your entry point, wrap your app in `ThemeProvider`, and render a `Chart` inside a container with an explicit height:
+
+```tsx
+import {ThemeProvider} from '@gravity-ui/uikit';
+import {Chart} from '@gravity-ui/charts';
+
+import '@gravity-ui/uikit/styles/fonts.css';
+import '@gravity-ui/uikit/styles/styles.css';
+
+const data = {
+  series: {
+    data: [
+      {
+        type: 'line',
+        name: 'Temperature',
+        data: [
+          {x: 0, y: 10},
+          {x: 1, y: 25},
+          {x: 2, y: 18},
+          {x: 3, y: 30},
+        ],
+      },
+    ],
+  },
+};
+
+export default function App() {
+  return (
+    <ThemeProvider theme="light">
+      <div style={{height: 300}}>
+        <Chart data={data} />
+      </div>
+    </ThemeProvider>
+  );
+}
+```
+
+`Chart` adapts to its parent's size, so the wrapping element must have a height.
+
 ## Documentation
 
 - [Overview](https://gravity-ui.github.io/charts/pages/overview.html)
@@ -9,3 +58,30 @@ React charting library with 10+ chart types: area, bar, line, pie, scatter, tree
 - [Development](https://gravity-ui.github.io/charts/pages/development.html)
 - [API](https://gravity-ui.github.io/charts/pages/api/overview.html)
 - [Guides](https://gravity-ui.github.io/charts/pages/guides/tooltip.html)
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## For AI agents
+
+A declarative React charting library for Gravity UI apps — render line, area, bar, pie, scatter, treemap, and other charts from a single `data` config, themed to match the rest of the app.
+
+### When to use
+
+- Standard business charts: `line`, `area`, `bar-x`/`bar-y`, `pie`, `scatter`, `treemap`, `waterfall`, `sankey`, `radar`, `heatmap`, `funnel`, `x-range`.
+- Visualizations that must follow Gravity UI theming (light/dark) and share tokens with a `@gravity-ui/uikit` app.
+- Rendering a chart from declarative data rather than drawing imperatively.
+
+### When not to use
+
+- Projects still on `@gravity-ui/chartkit` — that is the older adapter-based wrapper (YAGR/Highcharts/D3); this package is the modern standalone renderer and is not a drop-in replacement.
+- Plain tabular data — use [`@gravity-ui/table`](https://github.com/gravity-ui/table).
+- Non-React or server-only rendering — `Chart` renders React SVG and needs the DOM.
+
+### Common pitfalls
+
+- **The component is `Chart`, not `ChartKit`.** Import `{Chart}` from `@gravity-ui/charts`; `ChartKit` belongs to the separate legacy `@gravity-ui/chartkit` package.
+- **The data prop is `data`, shaped `{series: {data: [...]}}`.** Each entry in `series.data` is one series with its own `type` and `data` array — there is no top-level array of series.
+- **Nothing renders without a sized container.** `Chart` fills its parent, so give the wrapper an explicit height.
+- **Requires uikit setup.** Wrap in `ThemeProvider` and import `@gravity-ui/uikit/styles/styles.css`; `@gravity-ui/uikit` is a required peer dependency.


### PR DESCRIPTION
## What

- Adds a **Validate README** GitHub Action (`.github/workflows/validate-readme.yml`) that runs [`gravity-ui/readme-validator@v1`](https://github.com/gravity-ui/readme-validator) on the root `README.md` in CI.
- Brings the `README.md` up to the Gravity UI **LLM-ready template**: adds the missing `## License` section and a `## For AI agents` block (single-sentence positioning + *When to use* / *When not to use* / *Common pitfalls*).

## Why

The README is the source of truth for the generated `llms.txt` that coding agents read. The `## For AI agents` block gives agents crisp positioning, cross-links to the right neighbor packages, and the real hallucination traps (wrong prop/component names → correct ones). The workflow keeps the contract enforced on every PR.

Part of the Gravity UI LLM-adoption effort (DATAUI-3745).

🤖 Generated with [Claude Code](https://claude.com/claude-code)