### PR TITLE
fix: remove baseUrl, use relative imports

### DIFF
--- a/src/__tests__/bands.visual.test.tsx
+++ b/src/__tests__/bands.visual.test.tsx
@@ -4,6 +4,7 @@ import {expect, test} from '@playwright/experimental-ct-react';
 import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 
+import {ChartTestStory} from '../../playwright/components/ChartTestStory';
 import {
     barXDatePlotBandsData,
     barXPlotBandsData,
@@ -16,9 +17,7 @@ import {
     barYWithYAxisPlotBandsInfinityData,
     lineDatetimePlotBandData,
     lineTwoYAxisData,
-} from 'src/__stories__/__data__';
-
-import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+} from '../__stories__/__data__';
 
 test.describe('Plot Bands', () => {
     test('Category Y Plot Bands', async ({mount}) => {

--- a/src/__tests__/funnel.visual.test.tsx
+++ b/src/__tests__/funnel.visual.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {expect, test} from '@playwright/experimental-ct-react';
 
+import {ChartTestStory} from '../../playwright/components/ChartTestStory';
 import {
     funnelBasicData,
     funnelContinuousLegendData,
@@ -9,10 +10,8 @@ import {
     funnelMultilineLabelsData,
     funnelTrapezoidData,
     funnelTrapezoidWithConnectorsData,
-} from 'src/__stories__/__data__';
-import type {FunnelSeries} from 'src/types';
-
-import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+} from '../__stories__/__data__';
+import type {FunnelSeries} from '../types';
 
 import {FunnelTooltipValueFormatStory} from './components/FunnelTooltipValueFormatStory';
 import {getLocatorBoundingBox} from './utils';

--- a/src/__tests__/plot-lines.visual.test.tsx
+++ b/src/__tests__/plot-lines.visual.test.tsx
@@ -5,6 +5,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 import set from 'lodash/set';
 
+import {ChartTestStory} from '../../playwright/components/ChartTestStory';
 import {
     areaSplitData,
     barXDatePlotLineData,
@@ -12,9 +13,7 @@ import {
     barYDatetimePlotLineData,
     barYPlotLinesData,
     lineTwoYAxisData,
-} from 'src/__stories__/__data__';
-
-import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+} from '../__stories__/__data__';
 import type {ChartData} from '../types';
 
 test.describe('Plot Lines', () => {

--- a/src/__tests__/radar.visual.test.tsx
+++ b/src/__tests__/radar.visual.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import {expect, test} from '@playwright/experimental-ct-react';
 
-import {radarBasicData} from 'src/__stories__/__data__';
-
 import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+import {radarBasicData} from '../__stories__/__data__';
 
 test.describe('Radar series', () => {
     test('Basic', async ({mount}) => {

--- a/src/__tests__/tooltip.visual.test.tsx
+++ b/src/__tests__/tooltip.visual.test.tsx
@@ -4,16 +4,15 @@ import {expect, test} from '@playwright/experimental-ct-react';
 import cloneDeep from 'lodash/cloneDeep';
 import set from 'lodash/set';
 
+import {ChartTestStory} from '../../playwright/components/ChartTestStory';
 import {
     barXGroupedColumnsData,
     barXStakingPercentData,
     tooltipOverflowedRowsData,
     tooltipOverflowedRowsHtmlData,
-} from 'src/__stories__/__data__';
-import {TIME_UNITS} from 'src/core/utils/time';
-import type {ChartData} from 'src/types';
-
-import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+} from '../__stories__/__data__';
+import {TIME_UNITS} from '../core/utils/time';
+import type {ChartData} from '../types';
 
 import {DrawerChartTestStory} from './components/DrawerChartTestStory';
 import {HoveredPlotsTestStory} from './components/HoveredPlotsTestStory';

--- a/src/__tests__/treemap.visual.test.tsx
+++ b/src/__tests__/treemap.visual.test.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import {expect, test} from '@playwright/experimental-ct-react';
 import {median} from 'd3-array';
 
-import {treemapBasicData} from 'src/__stories__/__data__';
-import type {ChartData, TreemapSeries} from 'src/types';
 import {randomString} from '~core/utils';
 
 import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+import {treemapBasicData} from '../__stories__/__data__';
+import type {ChartData, TreemapSeries} from '../types';
 
 test.describe('Treemap series', () => {
     test('Basic', async ({mount}) => {

--- a/src/__tests__/update-chart/update-chart.visual.test.tsx
+++ b/src/__tests__/update-chart/update-chart.visual.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {expect, test} from '@playwright/experimental-ct-react';
 
-import type {ChartData} from 'src/types';
+import type {ChartData} from '../../types';
 
 import {ChartStory} from './ChartStory';
 

--- a/src/__tests__/waterfall.visual.test.tsx
+++ b/src/__tests__/waterfall.visual.test.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 
 import {expect, test} from '@playwright/experimental-ct-react';
 
+import {ChartTestStory} from '../../playwright/components/ChartTestStory';
 import {
     waterfallBasicData,
     waterfallNullModeSkipData,
     waterfallNullModeZeroData,
-} from 'src/__stories__/__data__';
-
-import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+} from '../__stories__/__data__';
 import type {ChartData, WaterfallSeriesData} from '../types';
 
 import {getLocatorBoundingBox} from './utils';

--- a/src/__tests__/x-range.visual.test.tsx
+++ b/src/__tests__/x-range.visual.test.tsx
@@ -4,10 +4,9 @@ import {expect, test} from '@playwright/experimental-ct-react';
 import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 
-import {xRangeBasicData, xRangeContinuousLegendData} from 'src/__stories__/__data__';
-import type {ChartData, DeepPartial, XRangeSeriesData} from 'src/types';
-
 import {ChartTestStory} from '../../playwright/components/ChartTestStory';
+import {xRangeBasicData, xRangeContinuousLegendData} from '../__stories__/__data__';
+import type {ChartData, DeepPartial, XRangeSeriesData} from '../types';
 
 import {dragElementByCalculatedPosition, getLocatorBoundingBox} from './utils';
 

--- a/src/components/AxisX/types.ts
+++ b/src/components/AxisX/types.ts
@@ -1,5 +1,4 @@
-import type {DashStyle} from 'src/core/constants';
-
+import type {DashStyle} from '../../core/constants';
 import type {AxisPlotShape} from '../../core/types/chart/axis';
 import type {BaseTextStyle, HtmlItem, PlotLayerPlacement, PointPosition} from '../../types';
 import type {TextRowData} from '../types';

--- a/src/components/AxisY/prepare-axis-title.ts
+++ b/src/components/AxisY/prepare-axis-title.ts
@@ -1,4 +1,3 @@
-import type {PreparedAxis} from 'src/hooks';
 import {
     calculateCos,
     calculateSin,
@@ -7,6 +6,7 @@ import {
     getTextWithElipsis,
 } from '~core/utils';
 
+import type {PreparedAxis} from '../../hooks';
 import type {TextRowData} from '../types';
 import {getMultilineTitleContentRows} from '../utils/axis-title';
 

--- a/src/components/AxisY/types.ts
+++ b/src/components/AxisY/types.ts
@@ -1,5 +1,4 @@
-import type {DashStyle} from 'src/core/constants';
-
+import type {DashStyle} from '../../core/constants';
 import type {AxisPlotShape} from '../../core/types/chart/axis';
 import type {CSSProperties} from '../../core/types/css';
 import type {BaseTextStyle, HtmlItem, PlotLayerPlacement, PointPosition} from '../../types';

--- a/src/core/utils/series/line.ts
+++ b/src/core/utils/series/line.ts
@@ -1,7 +1,7 @@
 import {select} from 'd3-selection';
 import {line} from 'd3-shape';
 
-import type {DashStyle} from 'src/core/constants';
+import type {DashStyle} from '../../constants';
 
 const linePathGenerator = line<{x: number; y: number}>()
     .x((d) => d.x)

--- a/src/libs/format-number/presets.ts
+++ b/src/libs/format-number/presets.ts
@@ -2,7 +2,6 @@ import type {FormatUnitScale} from './types';
 
 /**
  * Byte scale with binary base (`1024`) and localized postfixes.
- *
  * @example
  * ```ts
  * tooltip: {
@@ -28,7 +27,6 @@ export const FORMAT_UNITS_BYTES: FormatUnitScale = {
  * compactly as `K/M/B/T`. Postfixes are plain Latin letters and stay the
  * same regardless of language. The first entry has an empty postfix, so
  * values below `1000` render as plain numbers without a delimiter.
- *
  * @example
  * ```ts
  * tooltip: {
@@ -48,7 +46,6 @@ export const FORMAT_UNITS_NUMBERS: FormatUnitScale = {
 
 /**
  * Bit scale with decimal base (`1000`) and localized postfixes.
- *
  * @example
  * ```ts
  * tooltip: {

--- a/src/libs/format-number/types.ts
+++ b/src/libs/format-number/types.ts
@@ -76,7 +76,6 @@ export interface FormatNumberOptions extends FormatOptions {
      * - `'b'` — billions (÷ 1 000 000 000).
      * - `'t'` — trillions (÷ 1 000 000 000 000).
      * - `null` — no unit suffix.
-     *
      * @deprecated Use `units` for custom scales. This option is fully ignored when `units` is set.
      */
     unit?: 'auto' | 'k' | 'm' | 'b' | 't' | null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,13 @@
     "outDir": "build/esm",
     "module": "esnext",
     "jsx": "react",
-    "baseUrl": ".",
     "importHelpers": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "paths": {
-      "~playwright/*": ["playwright/*"],
-      "~core/*": ["src/core/*"],
-      "@gravity-ui/charts": ["src/index.ts"]
+      "~playwright/*": ["./playwright/*"],
+      "~core/*": ["./src/core/*"],
+      "@gravity-ui/charts": ["./src/index.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
`baseUrl` lets TS resolve non-relative imports relative to it, but
tsc does not rewrite these paths in emitted `.d.ts` files, breaking
type resolution for consumers.