### PR TITLE
fix(legend): preserve series order for integer-like group IDs

### DIFF
--- a/src/__tests__/legend.visual.test.tsx
+++ b/src/__tests__/legend.visual.test.tsx
@@ -180,6 +180,49 @@ test.describe('Legend', () => {
             await expect(component.locator('svg')).toHaveScreenshot();
         });
 
+        test('Preserves series order for integer-like group ids', async ({mount}) => {
+            const data: ChartData = {
+                legend: {
+                    enabled: true,
+                },
+                series: {
+                    data: [
+                        {
+                            type: 'line',
+                            name: 'First series',
+                            legend: {
+                                groupId: '10000',
+                            },
+                            data: [{x: 0, y: 1}],
+                        },
+                        {
+                            type: 'line',
+                            name: 'Second series',
+                            legend: {
+                                groupId: '1000',
+                            },
+                            data: [{x: 0, y: 2}],
+                        },
+                        {
+                            type: 'line',
+                            name: 'Third series',
+                            legend: {
+                                groupId: '999',
+                            },
+                            data: [{x: 0, y: 3}],
+                        },
+                    ],
+                },
+            };
+            const component = await mount(<ChartTestStory data={data} />);
+
+            await expect(component.locator('.gcharts-legend__item text')).toHaveText([
+                'First series',
+                'Second series',
+                'Third series',
+            ]);
+        });
+
         test.describe('Vertical alignment (position left)', () => {
             const verticalAlignOptions: ChartLegend['verticalAlign'][] = [
                 'top',

--- a/src/core/series/prepare-legend.ts
+++ b/src/core/series/prepare-legend.ts
@@ -1,4 +1,3 @@
-import {groupBy} from 'lodash';
 import clone from 'lodash/clone';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
@@ -112,8 +111,20 @@ export async function getPreparedLegend(args: {
 }
 
 function getFlattenLegendItems(series: PreparedSeries[], preparedLegend: PreparedLegend) {
-    const grouped = groupBy(series, (s) => s.legend.groupId);
-    return Object.values(grouped).reduce<LegendItemWithoutTextWidth[]>((acc, items) => {
+    const grouped = new Map<string, PreparedSeries[]>();
+
+    series.forEach((item) => {
+        const groupId = item.legend.groupId;
+        const items = grouped.get(groupId);
+
+        if (items) {
+            items.push(item);
+        } else {
+            grouped.set(groupId, [item]);
+        }
+    });
+
+    return Array.from(grouped.values()).reduce<LegendItemWithoutTextWidth[]>((acc, items) => {
         const s = items.find((item) => item.legend.enabled);
 
         if (s) {


### PR DESCRIPTION
Legend items now preserve the configured series order when groupId values are integer-like strings.

Fixes #652.