### PR TITLE
test: add regression test for invalid pie label placement

### DIFF
--- a/src/__tests__/pie-series.visual.test.tsx
+++ b/src/__tests__/pie-series.visual.test.tsx
@@ -346,6 +346,9 @@ test.describe('Pie series', () => {
         });
 
         test('skips label with invalid connector and continues placement', async ({mount}) => {
+            // Remove the expected-failure marker when applying this test with the fix for #649.
+            test.fail(true, 'Expected to fail on main until #649 is fixed');
+
             const data: ChartData = {
                 legend: {enabled: false},
                 series: {

--- a/src/__tests__/pie-series.visual.test.tsx
+++ b/src/__tests__/pie-series.visual.test.tsx
@@ -344,6 +344,34 @@ test.describe('Pie series', () => {
             const component = await mount(<ChartTestStory data={data} />);
             await expect(component.locator('svg')).toHaveScreenshot();
         });
+
+        test('skips label with invalid connector and continues placement', async ({mount}) => {
+            const data: ChartData = {
+                legend: {enabled: false},
+                series: {
+                    data: [
+                        {
+                            type: 'pie',
+                            borderWidth: 0,
+                            data: [
+                                {name: 'Small 0', value: 1, label: 'X00'},
+                                {name: 'Small 1', value: 1, label: 'X01'},
+                                {name: 'Small 2', value: 1, label: 'X02'},
+                                {name: 'Small 3', value: 1, label: 'X03'},
+                                {name: 'Small 4', value: 1, label: 'X04'},
+                                {name: 'Remainder', value: 355, label: 'X99'},
+                            ],
+                        },
+                    ],
+                },
+            };
+            const component = await mount(<ChartTestStory data={data} styles={{width: 280}} />);
+            const labels = component.locator('.gcharts-pie__label');
+
+            await expect(labels).toHaveCount(5);
+            await expect(labels.filter({hasText: 'X04'})).toHaveCount(0);
+            await expect(labels.filter({hasText: 'X99'})).toBeVisible();
+        });
     });
 
     test.describe('Min radius', () => {


### PR DESCRIPTION
Adds a regression test for #649. It verifies that when a pie label cannot be placed with a valid connector, only that label is skipped and the remaining labels are still rendered.