### PR TITLE
feat(legend): add item click event

### DIFF
--- a/src/__tests__/components/LegendItemClickTestStory.tsx
+++ b/src/__tests__/components/LegendItemClickTestStory.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import {ChartTestStory} from '../../../playwright/components/ChartTestStory';
+import type {ChartData} from '../../types';
+
+interface Props {
+    html?: boolean;
+    preventDefault?: boolean;
+}
+
+export const LegendItemClickTestStory = ({html = false, preventDefault = false}: Props) => {
+    const [clickedItem, setClickedItem] = React.useState('');
+    const data = React.useMemo<ChartData>(
+        () => ({
+            legend: {
+                enabled: true,
+                html,
+                events: {
+                    itemClick: (item, event) => {
+                        const custom = item.custom as {key: string};
+                        setClickedItem(`${item.name}:${item.visible}:${custom.key}`);
+
+                        if (preventDefault) {
+                            event.preventDefault();
+                        }
+                    },
+                },
+            },
+            series: {
+                data: [
+                    {
+                        type: 'line',
+                        name: 'First series',
+                        custom: {key: 'first'},
+                        data: [
+                            {x: 0, y: 1},
+                            {x: 1, y: 2},
+                        ],
+                    },
+                    {
+                        type: 'line',
+                        name: 'Second series',
+                        custom: {key: 'second'},
+                        data: [
+                            {x: 0, y: 2},
+                            {x: 1, y: 1},
+                        ],
+                    },
+                ],
+            },
+        }),
+        [html, preventDefault],
+    );
+
+    return (
+        <React.Fragment>
+            <ChartTestStory data={data} />
+            <output data-qa="clicked-legend-item">{clickedItem}</output>
+        </React.Fragment>
+    );
+};

--- a/src/__tests__/legend.visual.test.tsx
+++ b/src/__tests__/legend.visual.test.tsx
@@ -9,6 +9,7 @@ import {ChartTestStory} from '../../playwright/components/ChartTestStory';
 import {groupedLegend, pieHtmlLegendData} from '../__stories__/__data__';
 import type {ChartData, ChartLegend} from '../types';
 
+import {LegendItemClickTestStory} from './components/LegendItemClickTestStory';
 import {LONG_TEXT} from './constants';
 
 const pieOverflowedLegendItemsData: ChartData = {
@@ -127,6 +128,32 @@ test.describe('Legend', () => {
             // When clicking on the legend again, the chart should return to its original state.
             await legendItem.click();
             await expect(component.locator('svg')).toHaveScreenshot();
+        });
+
+        test('Item click event runs before the default SVG legend action', async ({mount}) => {
+            const component = await mount(<LegendItemClickTestStory />);
+            const legendItems = component.locator('.gcharts-legend__item text');
+
+            await legendItems.first().click();
+
+            await expect(component.locator('[data-qa="clicked-legend-item"]')).toHaveText(
+                'First series:true:first',
+            );
+            await expect(legendItems.nth(1)).toHaveClass(/gcharts-legend__item-text_unselected/);
+        });
+
+        test('Item click event can prevent the default HTML legend action', async ({mount}) => {
+            const component = await mount(
+                <LegendItemClickTestStory html={true} preventDefault={true} />,
+            );
+            const legendItems = component.locator('.gcharts-legend__item-text-html');
+
+            await legendItems.first().click();
+
+            await expect(component.locator('[data-qa="clicked-legend-item"]')).toHaveText(
+                'First series:true:first',
+            );
+            await expect(legendItems.nth(1)).toHaveClass(/gcharts-legend__item-text-html_selected/);
         });
 
         const positions = ['top', 'bottom', 'left', 'right'] as const;

--- a/src/components/Legend/index.tsx
+++ b/src/components/Legend/index.tsx
@@ -219,6 +219,28 @@ export const Legend = (props: Props) => {
             svgElement.style('opacity', 0);
 
             const isMac = navigator.platform.toUpperCase().includes('MAC');
+            const handleItemClick = (event: MouseEvent, item: LegendItem) => {
+                legend.events?.itemClick?.(
+                    {
+                        id: item.id,
+                        name: item.name,
+                        visible: Boolean(item.visible),
+                        custom: item.custom,
+                    },
+                    event,
+                );
+
+                if (event.defaultPrevented) {
+                    return;
+                }
+
+                onItemClick({
+                    id: item.id,
+                    name: item.name,
+                    metaKey: isMac ? event.metaKey : event.ctrlKey,
+                });
+                onUpdate?.();
+            };
 
             const htmlElement = select(htmlLayout);
             htmlElement.selectAll('[data-legend]').remove();
@@ -248,13 +270,8 @@ export const Legend = (props: Props) => {
                         .enter()
                         .append('g')
                         .attr('class', b('item'))
-                        .on('click', function (e, d) {
-                            onItemClick({
-                                id: d.id,
-                                name: d.name,
-                                metaKey: isMac ? e.metaKey : e.ctrlKey,
-                            });
-                            onUpdate?.();
+                        .on('click', function (event: MouseEvent, item) {
+                            handleItemClick(event, item);
                         });
 
                     const getXPosition = (i: number) => {
@@ -296,13 +313,8 @@ export const Legend = (props: Props) => {
                                 }
                                 return '0px';
                             })
-                            .on('click', function (e, d) {
-                                onItemClick({
-                                    id: d.id,
-                                    name: d.name,
-                                    metaKey: isMac ? e.metaKey : e.ctrlKey,
-                                });
-                                onUpdate?.();
+                            .on('click', function (event: MouseEvent, item) {
+                                handleItemClick(event, item);
                             })
                             .html((d) => d.text);
                     } else {

--- a/src/core/series/prepare-legend.ts
+++ b/src/core/series/prepare-legend.ts
@@ -86,6 +86,7 @@ export async function getPreparedLegend(args: {
         verticalAlign: get(legend, 'verticalAlign', legendDefaults.verticalAlign),
         justifyContent: get(legend, 'justifyContent', legendDefaults.justifyContent),
         enabled,
+        events: legend?.events,
         hangingOffset: itemHangingOffset,
         height,
         itemDistance: get(legend, 'itemDistance', legendDefaults.itemDistance),

--- a/src/core/series/types.ts
+++ b/src/core/series/types.ts
@@ -90,7 +90,8 @@ export type PreparedLegendSymbol = (RectLegendSymbol | PathLegendSymbol | Symbol
     bboxWidth: number;
 };
 
-export type PreparedLegend = Required<Omit<ChartLegend, 'title' | 'colorScale'>> & {
+export type PreparedLegend = Required<Omit<ChartLegend, 'title' | 'colorScale' | 'events'>> & {
+    events: ChartLegend['events'];
     hangingOffset: number;
     height: number;
     lineHeight: number;
@@ -120,6 +121,7 @@ export type OnLegendItemClick = (data: {id: string; name: string; metaKey: boole
 export type LegendItem = {
     id: string;
     color: string;
+    custom: MeaningfulAny;
     height: number;
     name: string;
     text: string;

--- a/src/core/types/chart/legend.ts
+++ b/src/core/types/chart/legend.ts
@@ -1,4 +1,17 @@
+import type {MeaningfulAny} from '../misc';
+
 import type {BaseTextStyle} from './base';
+
+export interface ChartLegendItemClickData {
+    id: string;
+    name: string;
+    visible: boolean;
+    custom?: MeaningfulAny;
+}
+
+export interface ChartLegendEvents {
+    itemClick?: (data: ChartLegendItemClickData, event: MouseEvent) => void;
+}
 
 export interface ChartLegendItem {
     enabled?: boolean;
@@ -12,6 +25,7 @@ export interface ChartLegendItem {
 }
 
 export interface ChartLegend extends ChartLegendItem {
+    events?: ChartLegendEvents;
     /**
      * Different types for different color schemes.
      * If the color scheme is continuous, a gradient legend will be drawn.


### PR DESCRIPTION
## Summary

- Adds a public `legend.events.itemClick` callback for discrete legend items.
- Supports both SVG and HTML legends.
- Exposes the item ID, name, current visibility, and series custom data.
- Invokes the callback before the built-in series visibility behavior.
- Allows consumers to cancel the default behavior with `event.preventDefault()`.

## Motivation

Legend items sometimes require application-specific interactions in addition to toggling series visibility. A cancellable click event allows consumers to implement those interactions without replacing the built-in legend renderer.

## API

```ts
const data = {
    legend: {
        events: {
            itemClick: (item, event) => {
                console.log({
                    id: item.id,
                    name: item.name,
                    visible: item.visible,
                    custom: item.custom,
                });

                event.preventDefault();
            },
        },
    },
};
```

The callback receives the legend item data and the native `MouseEvent`.

If `event.preventDefault()` is not called, the existing series visibility behavior remains unchanged. Calling it prevents the built-in visibility change.

## Testing

- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- Chromium component tests covering the default SVG legend behavior
- Chromium component tests covering cancellation in an HTML legend with `event.preventDefault()`